### PR TITLE
🔧 フロントエンドAPI URL設定の修正 - Hotfix

### DIFF
--- a/frontend/netlify.toml
+++ b/frontend/netlify.toml
@@ -1,0 +1,7 @@
+[build]
+  base = "frontend"
+  command = "npm run build"
+  publish = "dist"
+
+[build.environment]
+  SECRETS_SCAN_OMIT_KEYS = "VITE_API_BASE_URL" 

--- a/frontend/src/components/InputForm.tsx
+++ b/frontend/src/components/InputForm.tsx
@@ -41,8 +41,11 @@ function InputForm() {
     setIsSubmitting(true);
 
     try {
+      // 環境変数からAPI URLを取得
+      const API_BASE_URL = import.meta.env.VITE_API_BASE_URL || 'http://localhost:3001';
+      
       // バックエンドAPIを呼び出し
-      const response = await fetch('http://localhost:3001/api/reading-records', {
+      const response = await fetch(`${API_BASE_URL}/api/reading-records`, {
         method: 'POST',
         headers: {
           'Content-Type': 'application/json',

--- a/frontend/src/components/MyPage.tsx
+++ b/frontend/src/components/MyPage.tsx
@@ -23,7 +23,9 @@ function MyPage() {
   const fetchRecords = async () => {
     try {
       setLoading(true);
-      const response = await fetch('http://localhost:3001/api/reading-records');
+      // 環境変数からAPI URLを取得
+      const API_BASE_URL = import.meta.env.VITE_API_BASE_URL || 'http://localhost:3001';
+      const response = await fetch(`${API_BASE_URL}/api/reading-records`);
       
       if (!response.ok) {
         throw new Error(`HTTP error! status: ${response.status}`);

--- a/frontend/src/components/Timeline.tsx
+++ b/frontend/src/components/Timeline.tsx
@@ -59,7 +59,9 @@ function Timeline() {
   const fetchRecords = async () => {
     try {
       setLoading(true);
-      const response = await fetch(`http://localhost:3001/api/reading-records?sessionId=${sessionId}`);
+      // 環境変数からAPI URLを取得
+      const API_BASE_URL = import.meta.env.VITE_API_BASE_URL || 'http://localhost:3001';
+      const response = await fetch(`${API_BASE_URL}/api/reading-records?sessionId=${sessionId}`);
       
       if (!response.ok) {
         throw new Error(`HTTP error! status: ${response.status}`);
@@ -77,7 +79,9 @@ function Timeline() {
 
   const handleLike = async (recordId: number, isLiked: boolean) => {
     try {
-      const url = `http://localhost:3001/api/reading-records/${recordId}/like`;
+      // 環境変数からAPI URLを取得
+      const API_BASE_URL = import.meta.env.VITE_API_BASE_URL || 'http://localhost:3001';
+      const url = `${API_BASE_URL}/api/reading-records/${recordId}/like`;
       const method = isLiked ? 'DELETE' : 'POST';
       
       const response = await fetch(url, {


### PR DESCRIPTION
## 🔧 フロントエンドAPI URL設定の修正 - Hotfix

### 概要
本番環境（Netlify）でフロントエンドがローカル開発環境のAPIを呼び出してしまう問題を修正しました。環境変数`VITE_API_BASE_URL`を使用して、開発環境と本番環境で適切なAPIエンドポイントを選択できるようにしました。

### 問題
- **本番環境のフロントエンド**（Netlify）が`http://localhost:3001`のAPIを呼び出し
- **ローカル開発環境**が起動している場合、ローカルのデータベースのデータが表示される
- **Supabaseのサンプルデータ**が表示されない

### 修正内容

#### 1. InputForm.tsx
```typescript
// 修正前
const response = await fetch('http://localhost:3001/api/reading-records', {

// 修正後
const API_BASE_URL = import.meta.env.VITE_API_BASE_URL || 'http://localhost:3001';
const response = await fetch(`${API_BASE_URL}/api/reading-records`, {
```

#### 2. MyPage.tsx
```typescript
// 修正前
const response = await fetch('http://localhost:3001/api/reading-records');

// 修正後
const API_BASE_URL = import.meta.env.VITE_API_BASE_URL || 'http://localhost:3001';
const response = await fetch(`${API_BASE_URL}/api/reading-records`);
```

#### 3. Timeline.tsx
```typescript
// 修正前
const response = await fetch(`http://localhost:3001/api/reading-records?sessionId=${sessionId}`);
const url = `http://localhost:3001/api/reading-records/${recordId}/like`;

// 修正後
const API_BASE_URL = import.meta.env.VITE_API_BASE_URL || 'http://localhost:3001';
const response = await fetch(`${API_BASE_URL}/api/reading-records?sessionId=${sessionId}`);
const url = `${API_BASE_URL}/api/reading-records/${recordId}/like`;
```

### 技術的詳細

#### 環境変数の仕組み
- **開発環境**: `VITE_API_BASE_URL`が未設定の場合、`http://localhost:3001`を使用
- **本番環境**: Netlifyで`VITE_API_BASE_URL=https://[render-url].onrender.com`を設定

#### Vite環境変数の特徴
- `VITE_`プレフィックスが付いた環境変数は、フロントエンドで利用可能
- ビルド時に静的に置換される
- 本番環境では環境変数の値が直接埋め込まれる

### 影響範囲
- ✅ **開発環境**: 従来通りローカルAPIを使用
- ✅ **本番環境**: RenderのAPIを使用
- ✅ **入力機能**: 本番環境で正しいAPIに送信
- ✅ **マイページ**: 本番環境でSupabaseのデータを表示
- ✅ **タイムライン**: 本番環境でいいね機能も正常動作

### デプロイ後の設定
Netlifyで以下の環境変数を設定する必要があります：
```
VITE_API_BASE_URL=https://ichidan-dokusho-backend.onrender.com
```

### テスト方法
1. **開発環境**: ローカルDocker環境で動作確認
2. **本番環境**: Netlifyで環境変数設定後、Supabaseのデータが表示されることを確認

---

この修正により、本番環境でSupabaseのサンプルデータが正しく表示されるようになります。