### PR TITLE
feat: ソーシャルメディア連携機能の実装

### DIFF
--- a/frontend/src/components/MyPage.tsx
+++ b/frontend/src/components/MyPage.tsx
@@ -105,9 +105,22 @@ function MyPage() {
   // noteでシェア
   const shareOnNote = (learning: string, action: string, title: string) => {
     const text = generateSocialText(learning, action, title);
-    const encodedText = encodeURIComponent(text);
-    const url = `https://note.com/n/new?body=${encodedText}`;
-    window.open(url, '_blank');
+    
+    // クリップボードにコピー
+    navigator.clipboard.writeText(text).then(() => {
+      // noteのトップページに遷移
+      window.open('https://note.com/', '_blank');
+    }).catch(err => {
+      console.error('クリップボードへのコピーに失敗しました:', err);
+      // フォールバック: 古いブラウザ対応
+      const textArea = document.createElement('textarea');
+      textArea.value = text;
+      document.body.appendChild(textArea);
+      textArea.select();
+      document.execCommand('copy');
+      document.body.removeChild(textArea);
+      window.open('https://note.com/', '_blank');
+    });
   };
 
   if (loading) {
@@ -253,9 +266,14 @@ function MyPage() {
                   
                   if (!isWithinCharLimit) {
                     return (
-                      <p className="text-xs text-orange-500 mt-2">
-                        ※ 140文字を超えているため、noteでシェアします。
-                      </p>
+                      <div className="mt-2 space-y-1">
+                        <p className="text-xs text-orange-500">
+                          ※ 140文字を超えているため、noteでシェアします。
+                        </p>
+                        <p className="text-xs text-gray-500">
+                          ※ 内容がクリップボードにコピーされ、noteのトップページが開きます。
+                        </p>
+                      </div>
                     );
                   }
                   return null;

--- a/frontend/src/components/MyPage.tsx
+++ b/frontend/src/components/MyPage.tsx
@@ -230,19 +230,17 @@ function MyPage() {
                         // 140文字以内の場合：Xでシェア
                         <button
                           onClick={() => shareOnTwitter(record.learning, record.action, record.title)}
-                          className="flex-1 flex items-center justify-center space-x-2 px-4 py-2 rounded-lg font-medium bg-blue-500 text-white hover:bg-blue-600 transition-colors"
+                          className="flex-1 px-4 py-2 rounded-lg font-medium bg-blue-500 text-white hover:bg-blue-600 transition-colors"
                         >
-                          <span>𝕏</span>
-                          <span>Xでシェア</span>
+                          Xでシェア
                         </button>
                       ) : (
                         // 140文字を超える場合：noteでシェア
                         <button
                           onClick={() => shareOnNote(record.learning, record.action, record.title)}
-                          className="flex-1 flex items-center justify-center space-x-2 px-4 py-2 rounded-lg font-medium bg-green-500 text-white hover:bg-green-600 transition-colors"
+                          className="flex-1 px-4 py-2 rounded-lg font-medium bg-green-500 text-white hover:bg-green-600 transition-colors"
                         >
-                          <span>📝</span>
-                          <span>noteでシェア</span>
+                          noteでシェア
                         </button>
                       )}
                     </div>

--- a/frontend/src/components/MyPage.tsx
+++ b/frontend/src/components/MyPage.tsx
@@ -85,7 +85,7 @@ function MyPage() {
 
   // 学びとアクションを統合して140文字以内のテキストを生成
   const generateSocialText = (learning: string, action: string, title: string) => {
-    const combinedText = `📖 ${title}\n💡 ${learning}\n🎯 ${action}`;
+    const combinedText = `📖 ${title}\n💡 ${learning}\n🎯 ${action}\n#1段読書 #読書習慣\n👇 今すぐチェック！\nhttps://ichidan-dokusho.netlify.app/`;
     return combinedText;
   };
 
@@ -98,7 +98,7 @@ function MyPage() {
   const shareOnTwitter = (learning: string, action: string, title: string) => {
     const text = generateSocialText(learning, action, title);
     const encodedText = encodeURIComponent(text);
-    const url = `https://twitter.com/intent/tweet?text=${encodedText}&hashtags=1段読書,読書習慣`;
+    const url = `https://twitter.com/intent/tweet?text=${encodedText}`;
     window.open(url, '_blank');
   };
 

--- a/frontend/src/components/MyPage.tsx
+++ b/frontend/src/components/MyPage.tsx
@@ -83,6 +83,33 @@ function MyPage() {
     }
   };
 
+  // 学びとアクションを統合して140文字以内のテキストを生成
+  const generateSocialText = (learning: string, action: string, title: string) => {
+    const combinedText = `📖 ${title}\n💡 ${learning}\n🎯 ${action}`;
+    return combinedText;
+  };
+
+  // 文字数チェック（140文字以内かどうか）
+  const isWithinLimit = (text: string) => {
+    return text.length <= 140;
+  };
+
+  // X（Twitter）でシェア
+  const shareOnTwitter = (learning: string, action: string, title: string) => {
+    const text = generateSocialText(learning, action, title);
+    const encodedText = encodeURIComponent(text);
+    const url = `https://twitter.com/intent/tweet?text=${encodedText}&hashtags=1段読書,読書習慣`;
+    window.open(url, '_blank');
+  };
+
+  // noteでシェア
+  const shareOnNote = (learning: string, action: string, title: string) => {
+    const text = generateSocialText(learning, action, title);
+    const encodedText = encodeURIComponent(text);
+    const url = `https://note.com/n/new?body=${encodedText}`;
+    window.open(url, '_blank');
+  };
+
   if (loading) {
     return (
       <div className="bg-white/80 backdrop-blur-sm rounded-2xl shadow-xl p-8 border border-orange-100">
@@ -168,11 +195,63 @@ function MyPage() {
               </div>
 
               {/* アクション */}
-              <div>
+              <div className="mb-4">
                 <h4 className="font-medium text-gray-700 mb-2">🎯 明日のアクション</h4>
                 <p className="text-gray-800 bg-green-50 p-3 rounded-lg border-l-4 border-green-400">
                   {record.action}
                 </p>
+              </div>
+
+              {/* ソーシャルメディアシェア */}
+              <div className="border-t border-gray-200 pt-4">
+                <div className="flex items-center justify-between mb-3">
+                  <h4 className="font-medium text-gray-700">📱 シェア</h4>
+                  <div className="text-sm text-gray-500">
+                    {(() => {
+                      const text = generateSocialText(record.learning, record.action, record.title);
+                      const charCount = text.length;
+                      return (
+                        <span className={charCount > 140 ? 'text-red-500' : 'text-green-500'}>
+                          {charCount}/140文字
+                        </span>
+                      );
+                    })()}
+                  </div>
+                </div>
+                
+                <div className="flex space-x-2">
+                  <button
+                    onClick={() => shareOnTwitter(record.learning, record.action, record.title)}
+                    disabled={!isWithinLimit(generateSocialText(record.learning, record.action, record.title))}
+                    className={`flex-1 flex items-center justify-center space-x-2 px-4 py-2 rounded-lg font-medium transition-colors ${
+                      isWithinLimit(generateSocialText(record.learning, record.action, record.title))
+                        ? 'bg-blue-500 text-white hover:bg-blue-600'
+                        : 'bg-gray-300 text-gray-500 cursor-not-allowed'
+                    }`}
+                  >
+                    <span>𝕏</span>
+                    <span>Xでシェア</span>
+                  </button>
+                  
+                  <button
+                    onClick={() => shareOnNote(record.learning, record.action, record.title)}
+                    disabled={!isWithinLimit(generateSocialText(record.learning, record.action, record.title))}
+                    className={`flex-1 flex items-center justify-center space-x-2 px-4 py-2 rounded-lg font-medium transition-colors ${
+                      isWithinLimit(generateSocialText(record.learning, record.action, record.title))
+                        ? 'bg-green-500 text-white hover:bg-green-600'
+                        : 'bg-gray-300 text-gray-500 cursor-not-allowed'
+                    }`}
+                  >
+                    <span>📝</span>
+                    <span>noteでシェア</span>
+                  </button>
+                </div>
+                
+                {!isWithinLimit(generateSocialText(record.learning, record.action, record.title)) && (
+                  <p className="text-xs text-red-500 mt-2">
+                    ※ 140文字を超えているため、シェアできません。内容を短縮してください。
+                  </p>
+                )}
               </div>
             </div>
           ))}

--- a/frontend/src/components/MyPage.tsx
+++ b/frontend/src/components/MyPage.tsx
@@ -210,48 +210,58 @@ function MyPage() {
                     {(() => {
                       const text = generateSocialText(record.learning, record.action, record.title);
                       const charCount = text.length;
+                      const isWithinCharLimit = isWithinLimit(text);
                       return (
-                        <span className={charCount > 140 ? 'text-red-500' : 'text-green-500'}>
-                          {charCount}/140文字
+                        <span className={isWithinCharLimit ? 'text-green-500' : 'text-orange-500'}>
+                          {charCount}/140文字 {isWithinCharLimit ? '(Xでシェア可能)' : '(noteでシェア)'}
                         </span>
                       );
                     })()}
                   </div>
                 </div>
                 
-                <div className="flex space-x-2">
-                  <button
-                    onClick={() => shareOnTwitter(record.learning, record.action, record.title)}
-                    disabled={!isWithinLimit(generateSocialText(record.learning, record.action, record.title))}
-                    className={`flex-1 flex items-center justify-center space-x-2 px-4 py-2 rounded-lg font-medium transition-colors ${
-                      isWithinLimit(generateSocialText(record.learning, record.action, record.title))
-                        ? 'bg-blue-500 text-white hover:bg-blue-600'
-                        : 'bg-gray-300 text-gray-500 cursor-not-allowed'
-                    }`}
-                  >
-                    <span>𝕏</span>
-                    <span>Xでシェア</span>
-                  </button>
+                {(() => {
+                  const text = generateSocialText(record.learning, record.action, record.title);
+                  const isWithinCharLimit = isWithinLimit(text);
                   
-                  <button
-                    onClick={() => shareOnNote(record.learning, record.action, record.title)}
-                    disabled={!isWithinLimit(generateSocialText(record.learning, record.action, record.title))}
-                    className={`flex-1 flex items-center justify-center space-x-2 px-4 py-2 rounded-lg font-medium transition-colors ${
-                      isWithinLimit(generateSocialText(record.learning, record.action, record.title))
-                        ? 'bg-green-500 text-white hover:bg-green-600'
-                        : 'bg-gray-300 text-gray-500 cursor-not-allowed'
-                    }`}
-                  >
-                    <span>📝</span>
-                    <span>noteでシェア</span>
-                  </button>
-                </div>
+                  return (
+                    <div className="flex space-x-2">
+                      {isWithinCharLimit ? (
+                        // 140文字以内の場合：Xでシェア
+                        <button
+                          onClick={() => shareOnTwitter(record.learning, record.action, record.title)}
+                          className="flex-1 flex items-center justify-center space-x-2 px-4 py-2 rounded-lg font-medium bg-blue-500 text-white hover:bg-blue-600 transition-colors"
+                        >
+                          <span>𝕏</span>
+                          <span>Xでシェア</span>
+                        </button>
+                      ) : (
+                        // 140文字を超える場合：noteでシェア
+                        <button
+                          onClick={() => shareOnNote(record.learning, record.action, record.title)}
+                          className="flex-1 flex items-center justify-center space-x-2 px-4 py-2 rounded-lg font-medium bg-green-500 text-white hover:bg-green-600 transition-colors"
+                        >
+                          <span>📝</span>
+                          <span>noteでシェア</span>
+                        </button>
+                      )}
+                    </div>
+                  );
+                })()}
                 
-                {!isWithinLimit(generateSocialText(record.learning, record.action, record.title)) && (
-                  <p className="text-xs text-red-500 mt-2">
-                    ※ 140文字を超えているため、シェアできません。内容を短縮してください。
-                  </p>
-                )}
+                {(() => {
+                  const text = generateSocialText(record.learning, record.action, record.title);
+                  const isWithinCharLimit = isWithinLimit(text);
+                  
+                  if (!isWithinCharLimit) {
+                    return (
+                      <p className="text-xs text-orange-500 mt-2">
+                        ※ 140文字を超えているため、noteでシェアします。
+                      </p>
+                    );
+                  }
+                  return null;
+                })()}
               </div>
             </div>
           ))}


### PR DESCRIPTION
## 📱 ソーシャルメディア連携機能の実装

### 🎯 実装内容

#### **X（Twitter）連携**
- 140文字以内の投稿をXでシェア可能
- 新しいフォーマットでアプリリンクとハッシュタグを追加
- フォーマット:
  ```
  📖 タイトル
  💡 学び
  🎯 アクション
  #1段読書 #読書習慣
  👇 今すぐチェック！
  https://ichidan-dokusho.netlify.app/
  ```

#### **note連携**
- 140文字を超える投稿をnoteでシェア
- クリップボードに内容をコピーしてnoteトップページに遷移
- ユーザーが手動でnoteに貼り付けて投稿

#### **UI改善**
- シェアボタンからアイコンを削除してテキストのみに変更
- 文字数カウンターでX/noteの判定を表示
- noteボタンの下に詳細な注釈を追加

### 🔧 技術的な変更

#### **MyPage.tsx**
- `generateSocialText()`: ハッシュタグとアプリリンクを追加
- `shareOnTwitter()`: 新しいフォーマットでツイート生成
- `shareOnNote()`: クリップボードコピー + noteトップページ遷移
- 注釈表示: ユーザーへの操作説明を追加

#### **ブラウザ対応**
- モダンブラウザ: `navigator.clipboard.writeText()`
- フォールバック: `document.execCommand('copy')`

### 📊 文字数判定ロジック
- 140文字以内: Xでシェア（青ボタン）
- 140文字超過: noteでシェア（緑ボタン）
- リアルタイム文字数カウンター表示

### 🚀 本番デプロイ手順

#### **Netlify（フロントエンド）**
1. このPRがマージされると自動デプロイ
2. 環境変数 `VITE_GOOGLE_CLIENT_ID` は既に設定済み
3. Secrets Scanning除外設定済み

#### **Render（バックエンド）**
1. このPRがマージされると自動デプロイ
2. 環境変数 `GOOGLE_CLIENT_ID` は既に設定済み

### 🧪 テスト方法
1. マイページにアクセス: https://ichidan-dokusho.netlify.app/mypage
2. 140文字以内の投稿で「Xでシェア」ボタンをテスト
3. 140文字を超える投稿で「noteでシェア」ボタンをテスト
4. クリップボードコピーとnote遷移を確認

### 📝 関連Issue
- Closes #15: 今日の学び、明日のアクションを統合して140文字以内であればマイページからXに連携できるようにする

### 🔗 関連PR
- 前回のPR: ユーザー固有の投稿機能実装 
