### PR TITLE
feat: Google Analytics実装

### DIFF
--- a/frontend/index.html
+++ b/frontend/index.html
@@ -5,6 +5,16 @@
     <link rel="icon" type="image/svg+xml" href="/vite.svg" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Vite + React + TS</title>
+    
+    <!-- Google tag (gtag.js) -->
+    <script async src="https://www.googletagmanager.com/gtag/js?id=G-NEMWYXHV2P"></script>
+    <script>
+      window.dataLayer = window.dataLayer || [];
+      function gtag(){dataLayer.push(arguments);}
+      gtag('js', new Date());
+
+      gtag('config', 'G-NEMWYXHV2P');
+    </script>
   </head>
   <body>
     <div id="root"></div>

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1,6 +1,6 @@
 import { GoogleOAuthProvider } from '@react-oauth/google';
-import { useState } from 'react';
-import { Link, Route, BrowserRouter as Router, Routes } from 'react-router-dom';
+import { useEffect, useState } from 'react';
+import { Link, Route, BrowserRouter as Router, Routes, useLocation } from 'react-router-dom';
 import './App.css';
 import AuthScreen from './components/AuthScreen';
 import InputForm from './components/InputForm';
@@ -12,6 +12,29 @@ import { AuthProvider, useAuth } from './contexts/AuthContext';
 
 const GOOGLE_CLIENT_ID = import.meta.env.VITE_GOOGLE_CLIENT_ID || '';
 
+// Google Analytics の型定義
+declare global {
+  interface Window {
+    gtag: (...args: any[]) => void;
+  }
+}
+
+// Google Analytics ページビュー追跡コンポーネント
+function PageTracker() {
+  const location = useLocation();
+
+  useEffect(() => {
+    // Google Analytics ページビューを送信
+    if (typeof window !== 'undefined' && window.gtag) {
+      window.gtag('config', 'G-NEMWYXHV2P', {
+        page_path: location.pathname + location.search,
+      });
+    }
+  }, [location]);
+
+  return null;
+}
+
 function AppContent() {
   const [isMenuOpen, setIsMenuOpen] = useState(false);
   const { isAuthenticated, logout } = useAuth();
@@ -22,6 +45,9 @@ function AppContent() {
 
   return (
     <div className="min-h-screen bg-gradient-to-br from-amber-50 via-orange-50 to-yellow-50">
+      {/* Google Analytics ページビュー追跡 */}
+      <PageTracker />
+      
       {/* ハンバーガーメニュー */}
       <div className="fixed top-4 right-4 z-50">
         <button

--- a/frontend/src/components/AuthScreen.tsx
+++ b/frontend/src/components/AuthScreen.tsx
@@ -2,6 +2,7 @@ import { GoogleLogin } from '@react-oauth/google';
 import React from 'react';
 import { useNavigate } from 'react-router-dom';
 import { useAuth } from '../contexts/AuthContext';
+import { trackError, trackUserLogin } from '../utils/analytics';
 
 const AuthScreen: React.FC = () => {
   const navigate = useNavigate();
@@ -30,16 +31,21 @@ const AuthScreen: React.FC = () => {
       // 認証情報を保存
       login(data.token, data.user);
       
+      // Google Analytics ログイン追跡
+      trackUserLogin('google');
+      
       // 入力画面に遷移
       navigate('/input');
     } catch (error) {
       console.error('Authentication error:', error);
+      trackError('authentication_failed', error instanceof Error ? error.message : 'Unknown error');
       alert('認証に失敗しました。もう一度お試しください。');
     }
   };
 
   const handleGoogleError = () => {
     console.error('Google login failed');
+    trackError('google_login_failed', 'Google OAuth error');
     alert('Google認証に失敗しました。もう一度お試しください。');
   };
 

--- a/frontend/src/components/InputForm.tsx
+++ b/frontend/src/components/InputForm.tsx
@@ -1,5 +1,6 @@
 import { useState } from 'react';
 import { useAuth } from '../contexts/AuthContext';
+import { trackError, trackPostCreation } from '../utils/analytics';
 
 interface FormData {
   title: string;
@@ -69,11 +70,15 @@ function InputForm() {
       const result = await response.json();
       console.log('送信成功:', result);
       
+      // Google Analytics 投稿作成追跡
+      trackPostCreation(formData.readingAmount);
+      
       // 成功時の処理
       alert('投稿が完了しました！');
       resetForm();
     } catch (error) {
       console.error('送信エラー:', error);
+      trackError('post_creation_failed', error instanceof Error ? error.message : 'Unknown error');
       alert('投稿に失敗しました。もう一度お試しください。');
     } finally {
       setIsSubmitting(false);

--- a/frontend/src/components/MyPage.tsx
+++ b/frontend/src/components/MyPage.tsx
@@ -1,5 +1,6 @@
 import { useEffect, useState } from 'react';
 import { useAuth } from '../contexts/AuthContext';
+import { trackShare } from '../utils/analytics';
 
 interface ReadingRecord {
   id: number;
@@ -99,12 +100,19 @@ function MyPage() {
     const text = generateSocialText(learning, action, title);
     const encodedText = encodeURIComponent(text);
     const url = `https://twitter.com/intent/tweet?text=${encodedText}`;
+    
+    // Google Analytics シェア追跡
+    trackShare('twitter', text.length);
+    
     window.open(url, '_blank');
   };
 
   // noteでシェア
   const shareOnNote = (learning: string, action: string, title: string) => {
     const text = generateSocialText(learning, action, title);
+    
+    // Google Analytics シェア追跡
+    trackShare('note', text.length);
     
     // クリップボードにコピー
     navigator.clipboard.writeText(text).then(() => {

--- a/frontend/src/utils/analytics.ts
+++ b/frontend/src/utils/analytics.ts
@@ -1,0 +1,52 @@
+// Google Analytics カスタムイベント追跡ユーティリティ
+
+// ページビュー追跡
+export const trackPageView = (pagePath: string) => {
+  if (typeof window !== 'undefined' && window.gtag) {
+    window.gtag('config', 'G-NEMWYXHV2P', {
+      page_path: pagePath,
+    });
+  }
+};
+
+// カスタムイベント追跡
+export const trackEvent = (action: string, category: string, label?: string, value?: number) => {
+  if (typeof window !== 'undefined' && window.gtag) {
+    window.gtag('event', action, {
+      event_category: category,
+      event_label: label,
+      value: value,
+    });
+  }
+};
+
+// ユーザー登録追跡
+export const trackUserRegistration = (method: string) => {
+  trackEvent('sign_up', 'engagement', method);
+};
+
+// ログイン追跡
+export const trackUserLogin = (method: string) => {
+  trackEvent('login', 'engagement', method);
+};
+
+// 投稿作成追跡
+export const trackPostCreation = (readingAmount: string) => {
+  trackEvent('post_creation', 'engagement', readingAmount);
+};
+
+// シェア追跡
+export const trackShare = (platform: string, charCount: number) => {
+  trackEvent('share', 'engagement', platform, charCount);
+};
+
+// いいね追跡
+export const trackLike = (action: 'like' | 'unlike') => {
+  trackEvent(action, 'engagement');
+};
+
+// エラー追跡
+export const trackError = (errorType: string, errorMessage: string) => {
+  trackEvent('error', 'error', errorType);
+  console.error(`Analytics Error: ${errorType} - ${errorMessage}`);
+}; 


### PR DESCRIPTION
## 📊 Google Analytics実装

### 🎯 実装内容

#### **Google Analyticsタグ設置**
- `frontend/index.html` にGoogle Analyticsタグを追加
- トラッキングID: `G-NEMWYXHV2P`
- 非同期読み込みでパフォーマンスを最適化

#### **ページビュー追跡**
- React Routerでのページ遷移を自動追跡
- `PageTracker`コンポーネントでページビューを送信
- SPAでの正確なページビュー計測

#### **カスタムイベント追跡**
- **ログイン追跡**: Google認証成功時
- **投稿作成追跡**: 読書量別（1文/1段落/1章/1冊）
- **シェア追跡**: X/note別、文字数別
- **エラー追跡**: 認証失敗、投稿失敗等

#### **ユーティリティ関数**
- `frontend/src/utils/analytics.ts` に追跡関数を集約
- TypeScript型定義で型安全性を確保
- 再利用可能な追跡関数群

### 🔧 技術的な変更

#### **index.html**
```html
<!-- Google tag (gtag.js) -->
<script async src="https://www.googletagmanager.com/gtag/js?id=G-NEMWYXHV2P"></script>
<script>
  window.dataLayer = window.dataLayer || [];
  function gtag(){dataLayer.push(arguments);}
  gtag('js', new Date());
  gtag('config', 'G-NEMWYXHV2P');
</script>
```

#### **App.tsx**
- `PageTracker`コンポーネントを追加
- `useLocation`でページ遷移を監視
- TypeScript型定義を追加

#### **analytics.ts**
- `trackPageView()`: ページビュー追跡
- `trackEvent()`: カスタムイベント追跡
- `trackUserLogin()`: ログイン追跡
- `trackPostCreation()`: 投稿作成追跡
- `trackShare()`: シェア追跡
- `trackError()`: エラー追跡

#### **コンポーネント更新**
- **AuthScreen**: ログイン成功/失敗追跡
- **InputForm**: 投稿作成成功/失敗追跡
- **MyPage**: シェアアクション追跡

### 📈 追跡されるイベント

#### **ページビュー**
- `/` (ホーム)
- `/auth` (認証画面)
- `/input` (入力画面)
- `/mypage` (マイページ)
- `/timeline` (タイムライン)

#### **ユーザーアクション**
- **ログイン**: Google認証成功
- **投稿作成**: 読書量別（1文/1段落/1章/1冊）
- **シェア**: X（140文字以内）、note（140文字超過）
- **エラー**: 認証失敗、投稿失敗、Google OAuth失敗

### 🚀 本番デプロイ手順

#### **Netlify（フロントエンド）**
1. このPRがマージされると自動デプロイ
2. Google Analyticsタグが自動的に有効化
3. リアルタイムレポートで動作確認可能

#### **Google Analytics設定**
1. Google Analyticsダッシュボードでリアルタイムレポートを確認
2. イベントレポートでカスタムイベントを確認
3. ページビューレポートでSPAのページ遷移を確認

### 🧪 テスト方法
1. ローカル環境でDocker起動: `docker-compose -f docker-compose.dev.yml up`
2. ブラウザの開発者ツールでNetworkタブを確認
3. Google Analyticsのリアルタイムレポートでイベントを確認
4. 各ページ遷移、ログイン、投稿、シェアをテスト

### 📊 期待される効果
- **ユーザー行動分析**: どの機能が最も使われているか
- **コンバージョン分析**: ログインから投稿までの導線
- **エラー分析**: どの段階でエラーが発生しているか
- **シェア分析**: どのプラットフォームが人気か

### 📝 関連Issue
- Closes #22: GAのタグを設置する

### 🔗 関連PR
- 前回のPR: ソーシャルメディア連携機能実装 
