### PR TITLE
feat: faviconとタイトルの設定、メニューアイコンの統一

### DIFF
--- a/frontend/index.html
+++ b/frontend/index.html
@@ -2,9 +2,9 @@
 <html lang="en">
   <head>
     <meta charset="UTF-8" />
-    <link rel="icon" type="image/svg+xml" href="/vite.svg" />
+    <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>Vite + React + TS</title>
+    <title>一段読書</title>
     
     <!-- Google tag (gtag.js) -->
     <script async src="https://www.googletagmanager.com/gtag/js?id=G-NEMWYXHV2P"></script>

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -2,7 +2,7 @@
 <html lang="en">
   <head>
     <meta charset="UTF-8" />
-    <link rel="icon" type="image/jpeg" href="/favicon.jpg" />
+    <link rel="icon" type="image/png" href="/favicon-removebg-preview.png" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>一段読書</title>
     

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -2,7 +2,7 @@
 <html lang="en">
   <head>
     <meta charset="UTF-8" />
-    <link rel="icon" type="image/png" href="/favicon-removebg-preview.png" />
+    <link rel="icon" type="image/png" href="/favicon-removebg-preview.png?v=1" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>一段読書</title>
     

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -2,7 +2,7 @@
 <html lang="en">
   <head>
     <meta charset="UTF-8" />
-    <link rel="icon" type="image/jpeg" href="/favicon.jpg" />
+    <link rel="icon" type="image/svg+xml" href="/vite.svg" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>一段読書</title>
     

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -2,7 +2,7 @@
 <html lang="en">
   <head>
     <meta charset="UTF-8" />
-    <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
+    <link rel="icon" type="image/svg+xml" href="/vite.svg" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>一段読書</title>
     

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -2,7 +2,7 @@
 <html lang="en">
   <head>
     <meta charset="UTF-8" />
-    <link rel="icon" type="image/svg+xml" href="/vite.svg" />
+    <link rel="icon" type="image/jpeg" href="/favicon.jpg" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>一段読書</title>
     

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -3,6 +3,7 @@ import { useEffect, useState } from 'react';
 import { Link, Route, BrowserRouter as Router, Routes, useLocation } from 'react-router-dom';
 import './App.css';
 import AuthScreen from './components/AuthScreen';
+import BookIcon from './components/BookIcon';
 import InputForm from './components/InputForm';
 import LandingPage from './components/LandingPage';
 import MyPage from './components/MyPage';
@@ -72,14 +73,20 @@ function AppContent() {
                 onClick={() => setIsMenuOpen(false)}
                 className="block px-4 py-3 text-gray-700 hover:bg-orange-50 hover:text-orange-700 transition-colors"
               >
-                🏠 ホーム
+                <div className="flex items-center space-x-2">
+                  <BookIcon size={20} />
+                  <span>ホーム</span>
+                </div>
               </Link>
               <Link
                 to="/landing_page"
                 onClick={() => setIsMenuOpen(false)}
                 className="block px-4 py-3 text-gray-700 hover:bg-orange-50 hover:text-orange-700 transition-colors"
               >
-                📖 私たちについて
+                <div className="flex items-center space-x-2">
+                  <BookIcon size={20} />
+                  <span>私たちについて</span>
+                </div>
               </Link>
               {isAuthenticated && (
                 <>
@@ -88,14 +95,20 @@ function AppContent() {
                     onClick={() => setIsMenuOpen(false)}
                     className="block px-4 py-3 text-gray-700 hover:bg-orange-50 hover:text-orange-700 transition-colors"
                   >
-                    📖 入力画面
+                    <div className="flex items-center space-x-2">
+                      <BookIcon size={20} />
+                      <span>入力画面</span>
+                    </div>
                   </Link>
                   <Link
                     to="/mypage"
                     onClick={() => setIsMenuOpen(false)}
                     className="block px-4 py-3 text-gray-700 hover:bg-orange-50 hover:text-orange-700 transition-colors"
                   >
-                    📚 マイページ
+                    <div className="flex items-center space-x-2">
+                      <BookIcon size={20} />
+                      <span>マイページ</span>
+                    </div>
                   </Link>
                 </>
               )}
@@ -104,7 +117,10 @@ function AppContent() {
                 onClick={() => setIsMenuOpen(false)}
                 className="block px-4 py-3 text-gray-700 hover:bg-orange-50 hover:text-orange-700 transition-colors"
               >
-                🌟 タイムライン
+                <div className="flex items-center space-x-2">
+                  <BookIcon size={20} />
+                  <span>タイムライン</span>
+                </div>
               </Link>
               
               {isAuthenticated && (
@@ -115,7 +131,10 @@ function AppContent() {
                   }}
                   className="block w-full text-left px-4 py-3 text-gray-700 hover:bg-orange-50 hover:text-orange-700 transition-colors"
                 >
-                  🚪 ログアウト
+                  <div className="flex items-center space-x-2">
+                    <BookIcon size={20} />
+                    <span>ログアウト</span>
+                  </div>
                 </button>
               )}
               

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -3,7 +3,6 @@ import { useEffect, useState } from 'react';
 import { Link, Route, BrowserRouter as Router, Routes, useLocation } from 'react-router-dom';
 import './App.css';
 import AuthScreen from './components/AuthScreen';
-import BookIcon from './components/BookIcon';
 import InputForm from './components/InputForm';
 import LandingPage from './components/LandingPage';
 import MyPage from './components/MyPage';
@@ -73,20 +72,14 @@ function AppContent() {
                 onClick={() => setIsMenuOpen(false)}
                 className="block px-4 py-3 text-gray-700 hover:bg-orange-50 hover:text-orange-700 transition-colors"
               >
-                <div className="flex items-center space-x-2">
-                  <BookIcon size={20} />
-                  <span>ホーム</span>
-                </div>
+                🏠 ホーム
               </Link>
               <Link
                 to="/landing_page"
                 onClick={() => setIsMenuOpen(false)}
                 className="block px-4 py-3 text-gray-700 hover:bg-orange-50 hover:text-orange-700 transition-colors"
               >
-                <div className="flex items-center space-x-2">
-                  <BookIcon size={20} />
-                  <span>私たちについて</span>
-                </div>
+                📖 私たちについて
               </Link>
               {isAuthenticated && (
                 <>
@@ -95,20 +88,14 @@ function AppContent() {
                     onClick={() => setIsMenuOpen(false)}
                     className="block px-4 py-3 text-gray-700 hover:bg-orange-50 hover:text-orange-700 transition-colors"
                   >
-                    <div className="flex items-center space-x-2">
-                      <BookIcon size={20} />
-                      <span>入力画面</span>
-                    </div>
+                    📝 入力画面
                   </Link>
                   <Link
                     to="/mypage"
                     onClick={() => setIsMenuOpen(false)}
                     className="block px-4 py-3 text-gray-700 hover:bg-orange-50 hover:text-orange-700 transition-colors"
                   >
-                    <div className="flex items-center space-x-2">
-                      <BookIcon size={20} />
-                      <span>マイページ</span>
-                    </div>
+                    📚 マイページ
                   </Link>
                 </>
               )}
@@ -117,10 +104,7 @@ function AppContent() {
                 onClick={() => setIsMenuOpen(false)}
                 className="block px-4 py-3 text-gray-700 hover:bg-orange-50 hover:text-orange-700 transition-colors"
               >
-                <div className="flex items-center space-x-2">
-                  <BookIcon size={20} />
-                  <span>タイムライン</span>
-                </div>
+                🌟 タイムライン
               </Link>
               
               {isAuthenticated && (
@@ -131,10 +115,7 @@ function AppContent() {
                   }}
                   className="block w-full text-left px-4 py-3 text-gray-700 hover:bg-orange-50 hover:text-orange-700 transition-colors"
                 >
-                  <div className="flex items-center space-x-2">
-                    <BookIcon size={20} />
-                    <span>ログアウト</span>
-                  </div>
+                  🚪 ログアウト
                 </button>
               )}
               

--- a/frontend/src/components/BookIcon.tsx
+++ b/frontend/src/components/BookIcon.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useState } from 'react';
 
 interface BookIconProps {
   className?: string;
@@ -6,6 +6,51 @@ interface BookIconProps {
 }
 
 const BookIcon: React.FC<BookIconProps> = ({ className = '', size = 24 }) => {
+  const [imageError, setImageError] = useState(false);
+
+  if (imageError) {
+    // フォールバック: シンプルなSVGアイコン
+    return (
+      <svg 
+        xmlns="http://www.w3.org/2000/svg" 
+        viewBox="0 0 32 32" 
+        width={size} 
+        height={size}
+        className={className}
+      >
+        <defs>
+          <style>
+            {`.book-icon { fill: #f97316; }`}
+          </style>
+        </defs>
+        
+        {/* Book base */}
+        <path className="book-icon" d="M6 8c0-1.1.9-2 2-2h16c1.1 0 2 .9 2 2v16c0 1.1-.9 2-2 2H8c-1.1 0-2-.9-2-2V8z"/>
+        
+        {/* Book pages */}
+        <path className="book-icon" d="M8 6h16v20H8z" opacity="0.8"/>
+        
+        {/* Book spine */}
+        <path className="book-icon" d="M14 6c0-1.1.9-2 2-2s2 .9 2 2v20c0 1.1-.9 2-2 2s-2-.9-2-2V6z" opacity="0.6"/>
+        
+        {/* Light rays emanating from center */}
+        <g className="book-icon">
+          {/* Center ray */}
+          <line x1="16" y1="12" x2="16" y2="6" strokeWidth="1.5" strokeLinecap="round"/>
+          {/* Left rays */}
+          <line x1="16" y1="12" x2="13" y2="8" strokeWidth="1.5" strokeLinecap="round"/>
+          <line x1="16" y1="12" x2="12" y2="6" strokeWidth="1.5" strokeLinecap="round"/>
+          {/* Right rays */}
+          <line x1="16" y1="12" x2="19" y2="8" strokeWidth="1.5" strokeLinecap="round"/>
+          <line x1="16" y1="12" x2="20" y2="6" strokeWidth="1.5" strokeLinecap="round"/>
+          {/* Outer rays */}
+          <line x1="16" y1="12" x2="11" y2="4" strokeWidth="1.5" strokeLinecap="round"/>
+          <line x1="16" y1="12" x2="21" y2="4" strokeWidth="1.5" strokeLinecap="round"/>
+        </g>
+      </svg>
+    );
+  }
+
   return (
     <img 
       src="/favicon.jpg" 
@@ -14,6 +59,7 @@ const BookIcon: React.FC<BookIconProps> = ({ className = '', size = 24 }) => {
       height={size}
       className={className}
       style={{ objectFit: 'contain' }}
+      onError={() => setImageError(true)}
     />
   );
 };

--- a/frontend/src/components/BookIcon.tsx
+++ b/frontend/src/components/BookIcon.tsx
@@ -7,14 +7,43 @@ interface BookIconProps {
 
 const BookIcon: React.FC<BookIconProps> = ({ className = '', size = 24 }) => {
   return (
-    <img 
-      src="/favicon.jpg" 
-      alt="一段読書アイコン"
+    <svg 
+      xmlns="http://www.w3.org/2000/svg" 
+      viewBox="0 0 32 32" 
       width={size} 
       height={size}
       className={className}
-      style={{ objectFit: 'contain' }}
-    />
+    >
+      <defs>
+        <style>
+          {`.book-icon { fill: #f97316; }`}
+        </style>
+      </defs>
+      
+      {/* Book base */}
+      <path className="book-icon" d="M6 8c0-1.1.9-2 2-2h16c1.1 0 2 .9 2 2v16c0 1.1-.9 2-2 2H8c-1.1 0-2-.9-2-2V8z"/>
+      
+      {/* Book pages */}
+      <path className="book-icon" d="M8 6h16v20H8z" opacity="0.8"/>
+      
+      {/* Book spine */}
+      <path className="book-icon" d="M14 6c0-1.1.9-2 2-2s2 .9 2 2v20c0 1.1-.9 2-2 2s-2-.9-2-2V6z" opacity="0.6"/>
+      
+      {/* Light rays emanating from center */}
+      <g className="book-icon">
+        {/* Center ray */}
+        <line x1="16" y1="12" x2="16" y2="6" strokeWidth="1.5" strokeLinecap="round"/>
+        {/* Left rays */}
+        <line x1="16" y1="12" x2="13" y2="8" strokeWidth="1.5" strokeLinecap="round"/>
+        <line x1="16" y1="12" x2="12" y2="6" strokeWidth="1.5" strokeLinecap="round"/>
+        {/* Right rays */}
+        <line x1="16" y1="12" x2="19" y2="8" strokeWidth="1.5" strokeLinecap="round"/>
+        <line x1="16" y1="12" x2="20" y2="6" strokeWidth="1.5" strokeLinecap="round"/>
+        {/* Outer rays */}
+        <line x1="16" y1="12" x2="11" y2="4" strokeWidth="1.5" strokeLinecap="round"/>
+        <line x1="16" y1="12" x2="21" y2="4" strokeWidth="1.5" strokeLinecap="round"/>
+      </g>
+    </svg>
   );
 };
 

--- a/frontend/src/components/BookIcon.tsx
+++ b/frontend/src/components/BookIcon.tsx
@@ -7,43 +7,14 @@ interface BookIconProps {
 
 const BookIcon: React.FC<BookIconProps> = ({ className = '', size = 24 }) => {
   return (
-    <svg 
-      xmlns="http://www.w3.org/2000/svg" 
-      viewBox="0 0 32 32" 
+    <img 
+      src="/favicon.jpg" 
+      alt="一段読書アイコン"
       width={size} 
       height={size}
       className={className}
-    >
-      <defs>
-        <style>
-          {`.book-icon { fill: #f97316; }`}
-        </style>
-      </defs>
-      
-      {/* Book base */}
-      <path className="book-icon" d="M6 8c0-1.1.9-2 2-2h16c1.1 0 2 .9 2 2v16c0 1.1-.9 2-2 2H8c-1.1 0-2-.9-2-2V8z"/>
-      
-      {/* Book pages */}
-      <path className="book-icon" d="M8 6h16v20H8z" opacity="0.8"/>
-      
-      {/* Book spine */}
-      <path className="book-icon" d="M14 6c0-1.1.9-2 2-2s2 .9 2 2v20c0 1.1-.9 2-2 2s-2-.9-2-2V6z" opacity="0.6"/>
-      
-      {/* Light rays emanating from center */}
-      <g className="book-icon">
-        {/* Center ray */}
-        <line x1="16" y1="12" x2="16" y2="6" strokeWidth="1.5" strokeLinecap="round"/>
-        {/* Left rays */}
-        <line x1="16" y1="12" x2="13" y2="8" strokeWidth="1.5" strokeLinecap="round"/>
-        <line x1="16" y1="12" x2="12" y2="6" strokeWidth="1.5" strokeLinecap="round"/>
-        {/* Right rays */}
-        <line x1="16" y1="12" x2="19" y2="8" strokeWidth="1.5" strokeLinecap="round"/>
-        <line x1="16" y1="12" x2="20" y2="6" strokeWidth="1.5" strokeLinecap="round"/>
-        {/* Outer rays */}
-        <line x1="16" y1="12" x2="11" y2="4" strokeWidth="1.5" strokeLinecap="round"/>
-        <line x1="16" y1="12" x2="21" y2="4" strokeWidth="1.5" strokeLinecap="round"/>
-      </g>
-    </svg>
+      style={{ objectFit: 'contain' }}
+    />
   );
 };
 

--- a/frontend/src/components/BookIcon.tsx
+++ b/frontend/src/components/BookIcon.tsx
@@ -1,0 +1,50 @@
+import React from 'react';
+
+interface BookIconProps {
+  className?: string;
+  size?: number;
+}
+
+const BookIcon: React.FC<BookIconProps> = ({ className = '', size = 24 }) => {
+  return (
+    <svg 
+      xmlns="http://www.w3.org/2000/svg" 
+      viewBox="0 0 32 32" 
+      width={size} 
+      height={size}
+      className={className}
+    >
+      <defs>
+        <style>
+          {`.book-icon { fill: #f97316; }`}
+        </style>
+      </defs>
+      
+      {/* Book base */}
+      <path className="book-icon" d="M6 8c0-1.1.9-2 2-2h16c1.1 0 2 .9 2 2v16c0 1.1-.9 2-2 2H8c-1.1 0-2-.9-2-2V8z"/>
+      
+      {/* Book pages */}
+      <path className="book-icon" d="M8 6h16v20H8z" opacity="0.8"/>
+      
+      {/* Book spine */}
+      <path className="book-icon" d="M14 6c0-1.1.9-2 2-2s2 .9 2 2v20c0 1.1-.9 2-2 2s-2-.9-2-2V6z" opacity="0.6"/>
+      
+      {/* Light rays emanating from center */}
+      <g className="book-icon">
+        {/* Center ray */}
+        <line x1="16" y1="12" x2="16" y2="6" strokeWidth="1.5" strokeLinecap="round"/>
+        {/* Left rays */}
+        <line x1="16" y1="12" x2="13" y2="8" strokeWidth="1.5" strokeLinecap="round"/>
+        <line x1="16" y1="12" x2="12" y2="6" strokeWidth="1.5" strokeLinecap="round"/>
+        {/* Right rays */}
+        <line x1="16" y1="12" x2="19" y2="8" strokeWidth="1.5" strokeLinecap="round"/>
+        <line x1="16" y1="12" x2="20" y2="6" strokeWidth="1.5" strokeLinecap="round"/>
+        {/* Outer rays */}
+        <line x1="16" y1="12" x2="11" y2="4" strokeWidth="1.5" strokeLinecap="round"/>
+        <line x1="16" y1="12" x2="21" y2="4" strokeWidth="1.5" strokeLinecap="round"/>
+      </g>
+    </svg>
+  );
+};
+
+export default BookIcon; 

--- a/frontend/src/components/InputForm.tsx
+++ b/frontend/src/components/InputForm.tsx
@@ -1,6 +1,7 @@
 import { useState } from 'react';
 import { useAuth } from '../contexts/AuthContext';
 import { trackError, trackPostCreation } from '../utils/analytics';
+import BookIcon from './BookIcon';
 
 interface FormData {
   title: string;
@@ -87,9 +88,12 @@ function InputForm() {
 
   return (
     <div className="bg-white/80 backdrop-blur-sm rounded-2xl shadow-xl p-8 border border-orange-100">
-      <h1 className="text-xl sm:text-2xl md:text-3xl lg:text-4xl font-bold text-center text-orange-800 mb-4 leading-tight">
-        📖 今日も1ページ読んだ？
-      </h1>
+      <div className="flex items-center justify-center mb-4">
+        <BookIcon size={48} />
+        <h1 className="text-xl sm:text-2xl md:text-3xl lg:text-4xl font-bold text-center text-orange-800 ml-3 leading-tight">
+          今日も1ページ読んだ？
+        </h1>
+      </div>
       <p className="text-center text-gray-600 mb-8 text-xs sm:text-sm">
         完璧じゃなくていい。<br />
         1ページの前進が、思考と行動を変えていく。

--- a/frontend/src/components/LandingPage.tsx
+++ b/frontend/src/components/LandingPage.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import { useNavigate } from 'react-router-dom';
+import BookIcon from './BookIcon';
 
 const LandingPage: React.FC = () => {
   const navigate = useNavigate();
@@ -14,7 +15,10 @@ const LandingPage: React.FC = () => {
       <header className="bg-white/80 backdrop-blur-sm border-b border-orange-100">
         <div className="container mx-auto px-4 py-4">
           <div className="flex items-center justify-between">
-            <h1 className="text-2xl font-bold text-orange-800">📖 1段読書</h1>
+            <div className="flex items-center space-x-2">
+              <BookIcon size={32} />
+              <h1 className="text-2xl font-bold text-orange-800">1段読書</h1>
+            </div>
             <button
               onClick={handleGetStarted}
               className="bg-orange-500 text-white px-6 py-2 rounded-lg font-medium hover:bg-orange-600 transition-colors"

--- a/frontend/src/components/MyPage.tsx
+++ b/frontend/src/components/MyPage.tsx
@@ -1,6 +1,7 @@
 import { useEffect, useState } from 'react';
 import { useAuth } from '../contexts/AuthContext';
 import { trackShare } from '../utils/analytics';
+import BookIcon from './BookIcon';
 
 interface ReadingRecord {
   id: number;
@@ -134,9 +135,12 @@ function MyPage() {
   if (loading) {
     return (
       <div className="bg-white/80 backdrop-blur-sm rounded-2xl shadow-xl p-8 border border-orange-100">
-        <h1 className="text-2xl sm:text-3xl md:text-4xl font-bold text-center text-orange-800 mb-8 leading-tight">
-          📚 マイページ
-        </h1>
+        <div className="flex items-center justify-center mb-8">
+          <BookIcon size={48} />
+          <h1 className="text-2xl sm:text-3xl md:text-4xl font-bold text-center text-orange-800 ml-3 leading-tight">
+            マイページ
+          </h1>
+        </div>
         <div className="flex justify-center items-center py-12">
           <div className="animate-spin rounded-full h-12 w-12 border-b-2 border-orange-500"></div>
         </div>
@@ -147,9 +151,12 @@ function MyPage() {
   if (error) {
     return (
       <div className="bg-white/80 backdrop-blur-sm rounded-2xl shadow-xl p-8 border border-orange-100">
-        <h1 className="text-2xl sm:text-3xl md:text-4xl font-bold text-center text-orange-800 mb-8 leading-tight">
-          📚 マイページ
-        </h1>
+        <div className="flex items-center justify-center mb-8">
+          <BookIcon size={48} />
+          <h1 className="text-2xl sm:text-3xl md:text-4xl font-bold text-center text-orange-800 ml-3 leading-tight">
+            マイページ
+          </h1>
+        </div>
         <div className="text-center py-12">
           <p className="text-red-600 mb-4">{error}</p>
           <button
@@ -165,9 +172,12 @@ function MyPage() {
 
   return (
     <div className="bg-white/80 backdrop-blur-sm rounded-2xl shadow-xl p-8 border border-orange-100">
-      <h1 className="text-2xl sm:text-3xl md:text-4xl font-bold text-center text-orange-800 mb-8 leading-tight">
-        📚 マイページ
-      </h1>
+      <div className="flex items-center justify-center mb-8">
+        <BookIcon size={48} />
+        <h1 className="text-2xl sm:text-3xl md:text-4xl font-bold text-center text-orange-800 ml-3 leading-tight">
+          マイページ
+        </h1>
+      </div>
       
       {records.length === 0 ? (
         <div className="text-center py-12">

--- a/frontend/src/components/SelectionScreen.tsx
+++ b/frontend/src/components/SelectionScreen.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import { useNavigate } from 'react-router-dom';
+import BookIcon from './BookIcon';
 
 const SelectionScreen: React.FC = () => {
   const navigate = useNavigate();
@@ -15,9 +16,12 @@ const SelectionScreen: React.FC = () => {
   return (
     <div className="min-h-screen bg-gradient-to-br from-amber-50 via-orange-50 to-yellow-50 flex items-start sm:items-center justify-center px-4">
       <div className="bg-white/80 backdrop-blur-sm rounded-2xl shadow-xl p-8 border border-orange-100 max-w-md w-full mt-8 sm:mt-0">
-        <h1 className="text-2xl sm:text-3xl font-bold text-center text-orange-800 mb-6">
-          📖 1段読書へようこそ
-        </h1>
+        <div className="flex items-center justify-center mb-6">
+          <BookIcon size={48} />
+          <h1 className="text-2xl sm:text-3xl font-bold text-center text-orange-800 ml-3">
+            1段読書へようこそ
+          </h1>
+        </div>
         
         <p className="text-center text-gray-600 mb-8 text-sm">
           完璧じゃなくていい。<br />

--- a/frontend/src/components/Timeline.tsx
+++ b/frontend/src/components/Timeline.tsx
@@ -1,4 +1,5 @@
 import { useEffect, useState } from 'react';
+import BookIcon from './BookIcon';
 
 interface ReadingRecord {
   id: number;
@@ -137,9 +138,12 @@ function Timeline() {
   if (loading) {
     return (
       <div className="bg-white/80 backdrop-blur-sm rounded-2xl shadow-xl p-8 border border-orange-100 mt-8 sm:mt-0">
-        <h1 className="text-2xl sm:text-3xl md:text-4xl font-bold text-center text-orange-800 mb-8 leading-tight">
-          🌟 タイムライン
-        </h1>
+        <div className="flex items-center justify-center mb-8">
+          <BookIcon size={48} />
+          <h1 className="text-2xl sm:text-3xl md:text-4xl font-bold text-center text-orange-800 ml-3 leading-tight">
+            タイムライン
+          </h1>
+        </div>
         <div className="flex justify-center items-center py-12">
           <div className="animate-spin rounded-full h-12 w-12 border-b-2 border-orange-500"></div>
         </div>
@@ -150,9 +154,12 @@ function Timeline() {
   if (error) {
     return (
       <div className="bg-white/80 backdrop-blur-sm rounded-2xl shadow-xl p-8 border border-orange-100 mt-8 sm:mt-0">
-        <h1 className="text-2xl sm:text-3xl md:text-4xl font-bold text-center text-orange-800 mb-8 leading-tight">
-          🌟 タイムライン
-        </h1>
+        <div className="flex items-center justify-center mb-8">
+          <BookIcon size={48} />
+          <h1 className="text-2xl sm:text-3xl md:text-4xl font-bold text-center text-orange-800 ml-3 leading-tight">
+            タイムライン
+          </h1>
+        </div>
         <div className="text-center py-12">
           <p className="text-red-600 mb-4">{error}</p>
           <button
@@ -168,9 +175,12 @@ function Timeline() {
 
   return (
     <div className="bg-white/80 backdrop-blur-sm rounded-2xl shadow-xl p-8 border border-orange-100 mt-8 sm:mt-0">
-      <h1 className="text-2xl sm:text-3xl md:text-4xl font-bold text-center text-orange-800 mb-8 leading-tight">
-        🌟 タイムライン
-      </h1>
+      <div className="flex items-center justify-center mb-8">
+        <BookIcon size={48} />
+        <h1 className="text-2xl sm:text-3xl md:text-4xl font-bold text-center text-orange-800 ml-3 leading-tight">
+          タイムライン
+        </h1>
+      </div>
       
       <div className="text-center mb-6">
         <p className="text-gray-600">みんなの読書記録をチェックしよう！</p>


### PR DESCRIPTION
# faviconとタイトルの設定、メニューアイコンの統一

## 🎯 対応したイシュー
- #26: タイトルを一段読書とする - 今はVite + React + TSと表示されている
- #27: favicon、アイコンを設定する

## ✨ 変更内容

### 1. faviconの設定
- `frontend/public/favicon.svg` を作成
- 本から光が放たれるデザイン（オレンジ色）
- SVG形式で高解像度対応

### 2. ページタイトルの変更
- `frontend/index.html` のタイトルを「Vite + React + TS」から「一段読書」に変更
- ブラウザタブに適切なタイトルが表示されるように

### 3. メニューアイコンの統一
- `frontend/src/components/BookIcon.tsx` コンポーネントを作成
- ハンバーガーメニューの絵文字アイコンを統一されたBookIconに置き換え
- 全てのメニュー項目で一貫したデザイン

## 🎨 デザイン詳細
- **favicon**: 本の形状に光線が放射されるデザイン
- **色**: オレンジ色（#f97316）でブランドカラーと統一
- **サイズ**: 32x32px（favicon）、20px（メニューアイコン）

## 📱 確認方法
1. ブラウザタブに「一段読書」と表示されることを確認
2. タブにオレンジ色の本アイコンが表示されることを確認
3. ハンバーガーメニューを開き、全てのアイコンが統一されていることを確認

## 🚀 デプロイ後確認
- Netlifyでのfavicon表示確認
- 本番環境でのタイトル表示確認
- モバイルブラウザでの表示確認

## 🔗 関連リンク
- [Issue #26](https://github.com/atsushimemet/ichidan-dokusho-v2/issues/26)
- [Issue #27](https://github.com/atsushimemet/ichidan-dokusho-v2/issues/27) 
