### PR TITLE
feat: Add PR indicator for Amazon links in Timeline and MyPage

### DIFF
--- a/frontend/src/components/MyPage.tsx
+++ b/frontend/src/components/MyPage.tsx
@@ -1,4 +1,5 @@
 import { useEffect, useState } from 'react';
+import { isAmazonLink } from '../utils/amazonUtils';
 import { trackShare } from '../utils/analytics';
 import BookIcon from './BookIcon';
 
@@ -201,14 +202,21 @@ function MyPage() {
               {/* リンク */}
               {record.link && (
                 <div className="mb-4">
-                  <a
-                    href={record.link}
-                    target="_blank"
-                    rel="noopener noreferrer"
-                    className="text-blue-600 hover:text-blue-800 text-sm underline break-all"
-                  >
-                    📎 リンクを開く
-                  </a>
+                  <div className="flex items-center space-x-2">
+                    <a
+                      href={record.link}
+                      target="_blank"
+                      rel="noopener noreferrer"
+                      className="text-blue-600 hover:text-blue-800 text-sm underline break-all"
+                    >
+                      📎 リンクを開く
+                    </a>
+                    {isAmazonLink(record.link) && (
+                      <span className="text-gray-500 text-xs bg-gray-100 px-2 py-1 rounded">
+                        PR
+                      </span>
+                    )}
+                  </div>
                 </div>
               )}
 

--- a/frontend/src/components/Timeline.tsx
+++ b/frontend/src/components/Timeline.tsx
@@ -1,4 +1,5 @@
 import { useEffect, useState } from 'react';
+import { isAmazonLink } from '../utils/amazonUtils';
 import BookIcon from './BookIcon';
 
 interface ReadingRecord {
@@ -230,14 +231,21 @@ function Timeline() {
               {/* リンク */}
               {record.link && (
                 <div className="mb-4">
-                  <a
-                    href={record.link}
-                    target="_blank"
-                    rel="noopener noreferrer"
-                    className="text-blue-600 hover:text-blue-800 text-sm underline break-all"
-                  >
-                    📎 リンクを開く
-                  </a>
+                  <div className="flex items-center space-x-2">
+                    <a
+                      href={record.link}
+                      target="_blank"
+                      rel="noopener noreferrer"
+                      className="text-blue-600 hover:text-blue-800 text-sm underline break-all"
+                    >
+                      📎 リンクを開く
+                    </a>
+                    {isAmazonLink(record.link) && (
+                      <span className="text-gray-500 text-xs bg-gray-100 px-2 py-1 rounded">
+                        PR
+                      </span>
+                    )}
+                  </div>
                 </div>
               )}
 

--- a/frontend/src/utils/amazonUtils.ts
+++ b/frontend/src/utils/amazonUtils.ts
@@ -17,7 +17,8 @@ export const isAmazonLink = (url: string): boolean => {
            hostname.includes('amazon.it') ||
            hostname.includes('amazon.es') ||
            hostname.includes('amazon.ca') ||
-           hostname.includes('amazon.com.au');
+           hostname.includes('amazon.com.au') ||
+           hostname === 'amzn.to'; // Amazonの短縮URL
   } catch (error) {
     // URLの形式が不正な場合はfalseを返す
     return false;

--- a/frontend/src/utils/amazonUtils.ts
+++ b/frontend/src/utils/amazonUtils.ts
@@ -1,0 +1,25 @@
+/**
+ * URLがAmazonリンクかどうかを判定する
+ * @param url 判定対象のURL
+ * @returns Amazonリンクの場合true、そうでなければfalse
+ */
+export const isAmazonLink = (url: string): boolean => {
+  try {
+    const urlObj = new URL(url);
+    const hostname = urlObj.hostname.toLowerCase();
+    
+    // Amazonのドメインをチェック
+    return hostname.includes('amazon.co.jp') || 
+           hostname.includes('amazon.com') || 
+           hostname.includes('amazon.co.uk') ||
+           hostname.includes('amazon.de') ||
+           hostname.includes('amazon.fr') ||
+           hostname.includes('amazon.it') ||
+           hostname.includes('amazon.es') ||
+           hostname.includes('amazon.ca') ||
+           hostname.includes('amazon.com.au');
+  } catch (error) {
+    // URLの形式が不正な場合はfalseを返す
+    return false;
+  }
+}; 


### PR DESCRIPTION
## 概要

タイムライン・マイページのリンクの右横に、Amazonリンクであればグレー文字でPR表記を表示する機能を実装しました。

## 実装内容

### 新規ファイル
-  - Amazonリンク判定ユーティリティ

### 更新ファイル
-  - AmazonリンクにPR表記を追加
-  - AmazonリンクにPR表記を追加

## 機能詳細

### Amazonリンク判定
- 複数のAmazonドメインに対応
  -  (日本)
  -  (アメリカ)
  -  (イギリス)
  -  (ドイツ)
  -  (フランス)
  -  (イタリア)
  -  (スペイン)
  -  (カナダ)
  -  (オーストラリア)
  -  (Amazon短縮URL)

### デザイン
- PR表記はグレー文字（）
- 背景もグレー（）
- 小さな角丸（）
- 控えめで目立ちすぎないデザイン

## テスト
- Amazonの通常URLでPR表記が表示されることを確認
- Amazon短縮URL（amzn.to）でもPR表記が表示されることを確認
- 非AmazonリンクではPR表記が表示されないことを確認

## 関連Issue
Closes #18