### PR TITLE
feat: 備考フィールドを追加（マイページでのみ表示）

### DIFF
--- a/backend/migration-add-notes-field.sql
+++ b/backend/migration-add-notes-field.sql
@@ -1,0 +1,5 @@
+-- 備考フィールドを追加するマイグレーション
+ALTER TABLE reading_records ADD COLUMN IF NOT EXISTS notes TEXT;
+
+-- 備考フィールドのコメントを追加
+COMMENT ON COLUMN reading_records.notes IS '読書に関する備考（どこで読んだのか、何ページ目か、どんなきっかけで読んだのか、教えてくれた人は誰かなど）'; 

--- a/backend/src/database.ts
+++ b/backend/src/database.ts
@@ -37,6 +37,7 @@ export interface ReadingRecord {
   reading_amount: string;
   learning: string;
   action: string;
+  notes?: string;
   user_id?: string;
   user_email?: string;
   created_at?: string;
@@ -57,11 +58,11 @@ export interface Like {
 export const createReadingRecord = async (record: ReadingRecord) => {
   try {
     const query = `
-      INSERT INTO reading_records (title, link, reading_amount, learning, action, user_id, user_email)
-      VALUES ($1, $2, $3, $4, $5, $6, $7)
+      INSERT INTO reading_records (title, link, reading_amount, learning, action, notes, user_id, user_email)
+      VALUES ($1, $2, $3, $4, $5, $6, $7, $8)
       RETURNING *
     `;
-    const values = [record.title, record.link, record.reading_amount, record.learning, record.action, record.user_id, record.user_email];
+    const values = [record.title, record.link, record.reading_amount, record.learning, record.action, record.notes, record.user_id, record.user_email];
     const result = await pool.query(query, values);
     return { success: true, data: result.rows[0] };
   } catch (error) {

--- a/backend/src/index.ts
+++ b/backend/src/index.ts
@@ -328,6 +328,7 @@ app.post('/api/reading-records', async (req, res) => {
       reading_amount,
       learning,
       action,
+      notes: req.body.notes,
       user_id: userId,
       user_email: userEmail
     };
@@ -360,7 +361,7 @@ app.put('/api/reading-records/:id', async (req, res) => {
       return res.status(400).json({ message: 'Invalid ID' });
     }
 
-    const { title, link, reading_amount, learning, action } = req.body;
+    const { title, link, reading_amount, learning, action, notes } = req.body;
     const updateData: Partial<ReadingRecord> = {};
 
     if (title) updateData.title = title;
@@ -371,6 +372,7 @@ app.put('/api/reading-records/:id', async (req, res) => {
     if (reading_amount) updateData.reading_amount = reading_amount;
     if (learning) updateData.learning = learning;
     if (action) updateData.action = action;
+    if (notes !== undefined) updateData.notes = notes;
 
     const result = await updateReadingRecord(id, updateData);
     if (result.success) {

--- a/frontend/src/components/InputForm.tsx
+++ b/frontend/src/components/InputForm.tsx
@@ -7,6 +7,7 @@ interface FormData {
   readingAmount: string;
   learning: string;
   action: string;
+  notes: string;
   isNotBook: boolean;
   customLink: string;
 }
@@ -17,6 +18,7 @@ function InputForm() {
     readingAmount: '',
     learning: '',
     action: '',
+    notes: '',
     isNotBook: false,
     customLink: ''
   });
@@ -80,6 +82,7 @@ function InputForm() {
       readingAmount: '',
       learning: '',
       action: '',
+      notes: '',
       isNotBook: false,
       customLink: ''
     });
@@ -111,6 +114,7 @@ function InputForm() {
           reading_amount: formData.readingAmount,
           learning: formData.learning,
           action: formData.action,
+          notes: formData.notes,
           isNotBook: formData.isNotBook,
           customLink: formData.customLink
         }),
@@ -320,6 +324,25 @@ function InputForm() {
             className="w-full px-4 py-3 border border-gray-300 rounded-lg focus:ring-2 focus:ring-orange-500 focus:border-transparent transition-colors resize-none"
             required
           />
+        </div>
+
+        {/* 5. 備考（マイページでのみ表示） */}
+        <div>
+          <label htmlFor="notes" className="block text-sm font-medium text-gray-700 mb-2">
+            5. 備考 <span className="text-xs text-gray-500">（マイページでのみ表示）</span>
+          </label>
+          <textarea
+            id="notes"
+            name="notes"
+            value={formData.notes}
+            onChange={handleInputChange}
+            placeholder="どこで読んだのか、何ページ目か、どんなきっかけで読んだのか、教えてくれた人は誰かなど"
+            rows={3}
+            className="w-full px-4 py-3 border border-gray-300 rounded-lg focus:ring-2 focus:ring-orange-500 focus:border-transparent transition-colors resize-none"
+          />
+          <p className="text-xs text-gray-500 mt-1">
+            この情報はあなたのマイページでのみ表示され、他のユーザーには公開されません
+          </p>
         </div>
 
         {/* 送信ボタン */}

--- a/frontend/src/components/MyPage.tsx
+++ b/frontend/src/components/MyPage.tsx
@@ -10,6 +10,7 @@ interface ReadingRecord {
   reading_amount: string;
   learning: string;
   action: string;
+  notes?: string;
   user_id?: string;
   user_email?: string;
   created_at: string;
@@ -280,6 +281,19 @@ function MyPage() {
                   </button>
                 </div>
               </div>
+
+              {/* 備考（マイページでのみ表示） */}
+              {record.notes && (
+                <div className="mb-4">
+                  <h4 className="font-medium text-gray-700 mb-2">📝 備考</h4>
+                  <div className="min-h-[80px] bg-gray-50 p-3 rounded-lg border-l-4 border-gray-400 flex items-center">
+                    <p className="text-gray-800">{record.notes}</p>
+                  </div>
+                  <p className="text-xs text-gray-500 mt-1">
+                    この情報はあなたのマイページでのみ表示されています
+                  </p>
+                </div>
+              )}
 
               {/* ソーシャルメディアシェア */}
               <div className="border-t border-gray-200 pt-4">


### PR DESCRIPTION
## 概要

読書記録に備考フィールドを追加し、マイページでのみ表示されるプライベート情報として実装しました。

## 変更内容

### データベース
- テーブルにフィールドを追加
- 適切なコメントを設定

### バックエンド
- 型定義にフィールドを追加
- 関数を更新
- APIエンドポイントでフィールドを処理

### フロントエンド
- コンポーネントに備考フィールドを追加
- プレースホルダーテキストを設定（どこで読んだのか、何ページ目か、どんなきっかけで読んだのか、教えてくれた人は誰かなど）
- マイページでのみ表示されることを明記

### マイページ
- 備考フィールドの表示を追加
- プライベート情報であることを明記

## 機能の特徴

- **プライバシー保護**: 備考はマイページでのみ表示され、他のユーザーには公開されません
- **柔軟な入力**: 任意フィールドなので、入力しなくても投稿できます
- **分かりやすいUI**: プレースホルダーテキストで入力例を提供
- **視覚的な区別**: マイページでは備考が専用のセクションで表示

## 関連Issue

Closes #33