### PR TITLE
feat: Q&Aページを作成し、読んだ量の色についての説明を移行

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -6,6 +6,7 @@ import AuthScreen from './components/AuthScreen';
 import InputForm from './components/InputForm';
 import LandingPage from './components/LandingPage';
 import MyPage from './components/MyPage';
+import QAPage from './components/QAPage';
 import SelectionScreen from './components/SelectionScreen';
 import Timeline from './components/Timeline';
 import { AuthProvider, useAuth } from './contexts/AuthContext';
@@ -115,6 +116,13 @@ function AppContent() {
               >
                 🌟 タイムライン
               </Link>
+              <Link
+                to="/qa"
+                onClick={() => setIsMenuOpen(false)}
+                className="block px-4 py-3 text-gray-700 hover:bg-orange-50 hover:text-orange-700 transition-colors"
+              >
+                ❓ Q&A
+              </Link>
               
               {isAuthenticated && (
                 <button
@@ -125,37 +133,7 @@ function AppContent() {
                 </button>
               )}
               
-              {/* 区切り線 */}
-              <div className="border-t border-orange-100 my-2"></div>
-              
-              {/* Q&A セクション */}
-              <div className="px-4 py-3">
-                <h3 className="font-semibold text-gray-800 mb-3">❓ Q&A</h3>
-                
-                <div className="space-y-3 text-sm">
-                  <div>
-                    <h4 className="font-medium text-gray-700 mb-2">読んだ量の色について</h4>
-                    <div className="space-y-2">
-                      <div className="flex items-center space-x-2">
-                        <div className="w-4 h-4 rounded-full bg-blue-500 flex-shrink-0"></div>
-                        <span className="text-gray-600">1文だけ</span>
-                      </div>
-                      <div className="flex items-center space-x-2">
-                        <div className="w-4 h-4 rounded-full bg-green-500 flex-shrink-0"></div>
-                        <span className="text-gray-600">1段落</span>
-                      </div>
-                      <div className="flex items-center space-x-2">
-                        <div className="w-4 h-4 rounded-full bg-orange-500 flex-shrink-0"></div>
-                        <span className="text-gray-600">1章</span>
-                      </div>
-                      <div className="flex items-center space-x-2">
-                        <div className="w-4 h-4 rounded-full bg-purple-500 flex-shrink-0"></div>
-                        <span className="text-gray-600">1冊・全文</span>
-                      </div>
-                    </div>
-                  </div>
-                </div>
-              </div>
+
             </div>
           </div>
         )}
@@ -193,6 +171,11 @@ function AppContent() {
         <Route path="/timeline" element={
           <div className="container mx-auto px-4 pt-0 pb-8 max-w-2xl">
             <Timeline />
+          </div>
+        } />
+        <Route path="/qa" element={
+          <div className="container mx-auto px-4 pt-0 pb-8 max-w-2xl">
+            <QAPage />
           </div>
         } />
       </Routes>

--- a/frontend/src/components/QAPage.tsx
+++ b/frontend/src/components/QAPage.tsx
@@ -1,0 +1,116 @@
+import BookIcon from './BookIcon';
+
+function QAPage() {
+  return (
+    <div className="bg-white/80 backdrop-blur-sm rounded-2xl shadow-xl p-8 border border-orange-100">
+      <div className="flex items-center justify-center mb-8">
+        <BookIcon size={48} />
+        <h1 className="text-2xl sm:text-3xl md:text-4xl font-bold text-center text-orange-800 ml-3 leading-tight">
+          Q&A
+        </h1>
+      </div>
+      
+      <div className="space-y-8">
+        {/* 読んだ量の色について */}
+        <div className="bg-orange-50 rounded-xl p-6 border border-orange-200">
+          <h2 className="text-xl font-semibold text-orange-800 mb-4 flex items-center">
+            <span className="mr-2">🎨</span>
+            読んだ量の色について
+          </h2>
+          <p className="text-gray-700 mb-4">
+            タイムラインでは、読んだ量に応じて色分けされたマーカーが表示されます。
+          </p>
+          <div className="grid grid-cols-1 sm:grid-cols-2 gap-4">
+            <div className="flex items-center space-x-3 p-3 bg-white rounded-lg border border-orange-100">
+              <div className="w-6 h-6 rounded-full bg-blue-500 flex-shrink-0"></div>
+              <div>
+                <span className="font-medium text-gray-800">1文だけ</span>
+                <p className="text-sm text-gray-600">短い文章を読んだ場合</p>
+              </div>
+            </div>
+            <div className="flex items-center space-x-3 p-3 bg-white rounded-lg border border-orange-100">
+              <div className="w-6 h-6 rounded-full bg-green-500 flex-shrink-0"></div>
+              <div>
+                <span className="font-medium text-gray-800">1段落</span>
+                <p className="text-sm text-gray-600">段落単位で読んだ場合</p>
+              </div>
+            </div>
+            <div className="flex items-center space-x-3 p-3 bg-white rounded-lg border border-orange-100">
+              <div className="w-6 h-6 rounded-full bg-orange-500 flex-shrink-0"></div>
+              <div>
+                <span className="font-medium text-gray-800">1章</span>
+                <p className="text-sm text-gray-600">章単位で読んだ場合</p>
+              </div>
+            </div>
+            <div className="flex items-center space-x-3 p-3 bg-white rounded-lg border border-orange-100">
+              <div className="w-6 h-6 rounded-full bg-purple-500 flex-shrink-0"></div>
+              <div>
+                <span className="font-medium text-gray-800">1冊・全文</span>
+                <p className="text-sm text-gray-600">本全体を読んだ場合</p>
+              </div>
+            </div>
+          </div>
+        </div>
+
+        {/* よくある質問 */}
+        <div className="bg-blue-50 rounded-xl p-6 border border-blue-200">
+          <h2 className="text-xl font-semibold text-blue-800 mb-4 flex items-center">
+            <span className="mr-2">❓</span>
+            よくある質問
+          </h2>
+          <div className="space-y-4">
+            <div className="bg-white rounded-lg p-4 border border-blue-100">
+              <h3 className="font-medium text-gray-800 mb-2">Q: 読書記録は誰でも見えますか？</h3>
+              <p className="text-gray-600">A: タイムラインでは全てのユーザーの読書記録が表示されますが、備考欄はマイページでのみ表示されるプライベート情報です。</p>
+            </div>
+            <div className="bg-white rounded-lg p-4 border border-blue-100">
+              <h3 className="font-medium text-gray-800 mb-2">Q: 書籍以外の記事も記録できますか？</h3>
+              <p className="text-gray-600">A: はい、書籍以外の記事やブログ、論文なども記録できます。入力画面で「書籍以外」を選択してください。</p>
+            </div>
+            <div className="bg-white rounded-lg p-4 border border-blue-100">
+              <h3 className="font-medium text-gray-800 mb-2">Q: 記録を削除できますか？</h3>
+              <p className="text-gray-600">A: 現在、記録の削除機能は提供していません。記録は永続的に保存されます。</p>
+            </div>
+          </div>
+        </div>
+
+        {/* Googleフォーム */}
+        <div className="bg-green-50 rounded-xl p-6 border border-green-200">
+          <h2 className="text-xl font-semibold text-green-800 mb-4 flex items-center">
+            <span className="mr-2">📝</span>
+            お問い合わせ・フィードバック
+          </h2>
+          <p className="text-gray-700 mb-4">
+            ご質問やご意見、改善提案などがございましたら、以下のフォームからお気軽にお送りください。
+          </p>
+          <div className="bg-white rounded-lg p-4 border border-green-100">
+            <iframe
+              src="https://forms.gle/KiRMCHHv6PYFEJZS6"
+              width="100%"
+              height="600"
+              frameBorder="0"
+              marginHeight={0}
+              marginWidth={0}
+              title="お問い合わせフォーム"
+              className="rounded-lg"
+            >
+              お問い合わせフォームを読み込んでいます...
+            </iframe>
+          </div>
+        </div>
+
+        {/* 戻るボタン */}
+        <div className="text-center pt-4">
+          <button
+            onClick={() => window.history.back()}
+            className="bg-gradient-to-r from-orange-500 to-yellow-500 text-white font-semibold py-3 px-6 rounded-lg hover:from-orange-600 hover:to-yellow-600 focus:ring-4 focus:ring-orange-300 transition-all duration-200"
+          >
+            ← 戻る
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+export default QAPage; 


### PR DESCRIPTION
## 概要

Q&Aページを作成し、ハンバーガーメニューにあった読んだ量の色についての説明を専用ページに移行しました。

## 変更内容

### 新規作成
- コンポーネントを新規作成
- ルートを追加

### Q&Aページの機能
- **読んだ量の色について**: 視覚的に分かりやすいカード形式で表示
  - 1文だけ（青）
  - 1段落（緑）
  - 1章（オレンジ）
  - 1冊・全文（紫）
- **よくある質問**: ユーザーがよく疑問に思う内容をQ&A形式で提供
  - 読書記録の公開範囲について
  - 書籍以外の記録について
  - 記録の削除について
- **Googleフォーム**: お問い合わせ・フィードバック用のフォームを埋め込み

### ハンバーガーメニューの更新
- Q&Aセクションを削除
- Q&Aページへのリンクを追加（❓ Q&A）

### デザイン
- レスポンシブデザイン対応
- 他のページと一貫したUI
- セクションごとに色分けされた背景

## アクセス方法
- ハンバーガーメニューから「❓ Q&A」を選択
- 直接URL: でアクセス

## 関連Issue

Closes #37