### PR TITLE
Fix like count displaying '01' instead of '1' (Issue #41)

### DIFF
--- a/frontend/src/components/Timeline.tsx
+++ b/frontend/src/components/Timeline.tsx
@@ -11,7 +11,7 @@ interface ReadingRecord {
   action: string;
   created_at: string;
   updated_at: string;
-  like_count?: number;
+  like_count?: number | string;
   is_liked?: boolean;
 }
 
@@ -105,15 +105,15 @@ function Timeline() {
                   ...record,
                   is_liked: !isLiked,
                   like_count: isLiked 
-                    ? Math.max(0, (record.like_count ?? 0) - 1)
-                    : (record.like_count ?? 0) + 1
+                    ? Math.max(0, Number(record.like_count ?? 0) - 1)
+                    : Number(record.like_count ?? 0) + 1
                 }
               : record
           )
         );
         
         // デバッグ用ログ
-        console.log('Like action:', { recordId, isLiked, newLikeCount: isLiked ? Math.max(0, (records.find(r => r.id === recordId)?.like_count ?? 0) - 1) : (records.find(r => r.id === recordId)?.like_count ?? 0) + 1 });
+        console.log('Like action:', { recordId, isLiked, newLikeCount: isLiked ? Math.max(0, Number(records.find(r => r.id === recordId)?.like_count ?? 0) - 1) : Number(records.find(r => r.id === recordId)?.like_count ?? 0) + 1 });
       }
     } catch (error) {
       console.error('いいねエラー:', error);
@@ -233,7 +233,7 @@ function Timeline() {
                     <span className={record.is_liked ? 'text-red-500' : 'text-gray-400'}>
                       {record.is_liked ? '❤️' : '🤍'}
                     </span>
-                    <span>{record.like_count ?? 0}</span>
+                    <span>{Number(record.like_count ?? 0)}</span>
                   </button>
                 </div>
               </div>


### PR DESCRIPTION
- Convert like_count to Number before arithmetic operations to prevent string concatenation
- Update display logic to ensure consistent number formatting
- Update TypeScript interface to accept both number and string types for like_count
- Fix state update calculations in handleLike function

🤖 Generated with [Claude Code](https://claude.ai/code)