### PR TITLE
feat: 書籍名表示の最適化 - iPhone SEサイズ対応

### DIFF
--- a/frontend/src/components/MyPage.tsx
+++ b/frontend/src/components/MyPage.tsx
@@ -340,7 +340,9 @@ function MyPage() {
               {/* ヘッダー */}
               <div className="mb-4">
                 {/* 書籍タイトル */}
-                <h3 className="font-semibold text-lg text-gray-800 line-clamp-2 leading-tight mb-2">{record.title}</h3>
+                <h3 className="font-semibold text-base text-gray-800 line-clamp-2 leading-tight mb-2">
+                  {record.title.length > 30 ? `${record.title.substring(0, 30)}...` : record.title}
+                </h3>
                 
                 {/* 読んだ量 */}
                 <div className="flex items-center space-x-2 mb-2">

--- a/frontend/src/components/MyPage.tsx
+++ b/frontend/src/components/MyPage.tsx
@@ -341,8 +341,8 @@ function MyPage() {
               <div className="flex items-start justify-between mb-4">
                 <div className="flex items-center space-x-3">
                   <span className="text-2xl">{getReadingAmountIcon(record.reading_amount)}</span>
-                  <div>
-                    <h3 className="font-semibold text-lg text-gray-800">{record.title}</h3>
+                  <div className="flex-1 min-w-0">
+                    <h3 className="font-semibold text-lg text-gray-800 line-clamp-2 leading-tight">{record.title}</h3>
                     <p className="text-sm text-gray-500">{formatDate(record.created_at)}</p>
                   </div>
                 </div>

--- a/frontend/src/components/MyPage.tsx
+++ b/frontend/src/components/MyPage.tsx
@@ -338,16 +338,22 @@ function MyPage() {
               className="bg-white rounded-xl shadow-md border border-orange-100 p-6 hover:shadow-lg transition-shadow"
             >
               {/* ヘッダー */}
-              <div className="flex items-start justify-between mb-4">
-                <div className="flex items-center space-x-3">
-                  <span className="text-2xl">{getReadingAmountIcon(record.reading_amount)}</span>
-                  <div className="flex-1 min-w-0">
-                    <h3 className="font-semibold text-lg text-gray-800 line-clamp-2 leading-tight">{record.title}</h3>
-                    <p className="text-sm text-gray-500">{formatDate(record.created_at)}</p>
-                  </div>
+              <div className="mb-4">
+                {/* 書籍タイトル */}
+                <h3 className="font-semibold text-lg text-gray-800 line-clamp-2 leading-tight mb-2">{record.title}</h3>
+                
+                {/* 読んだ量 */}
+                <div className="flex items-center space-x-2 mb-2">
+                  <span className="text-xl">{getReadingAmountIcon(record.reading_amount)}</span>
+                  <span className="text-sm text-gray-600">{record.reading_amount}</span>
+                  <div className={`w-3 h-3 rounded-full ${getReadingAmountColor(record.reading_amount)} flex-shrink-0`}></div>
                 </div>
+                
+                {/* 登録日 */}
+                <p className="text-sm text-gray-500 mb-2">{formatDate(record.created_at)}</p>
+                
+                {/* 編集・削除ボタン */}
                 <div className="flex items-center space-x-2">
-                  <div className={`w-4 h-4 rounded-full ${getReadingAmountColor(record.reading_amount)} flex-shrink-0`}></div>
                   <button
                     onClick={() => startEdit(record)}
                     className="text-blue-500 hover:text-blue-700 hover:bg-blue-50 p-1 rounded-full transition-colors"

--- a/frontend/src/components/MyPage.tsx
+++ b/frontend/src/components/MyPage.tsx
@@ -341,7 +341,12 @@ function MyPage() {
               <div className="mb-4">
                 {/* 書籍タイトル */}
                 <h3 className="font-semibold text-base text-gray-800 line-clamp-2 leading-tight mb-2">
-                  {record.title.length > 30 ? `${record.title.substring(0, 30)}...` : record.title}
+                  <span className="sm:hidden">
+                    {record.title.length > 30 ? `${record.title.substring(0, 30)}...` : record.title}
+                  </span>
+                  <span className="hidden sm:block">
+                    {record.title}
+                  </span>
                 </h3>
                 
                 {/* 読んだ量 */}

--- a/frontend/src/components/Timeline.tsx
+++ b/frontend/src/components/Timeline.tsx
@@ -213,7 +213,9 @@ function Timeline() {
               {/* ヘッダー */}
               <div className="mb-4">
                 {/* 書籍タイトル */}
-                <h3 className="font-semibold text-lg text-gray-800 line-clamp-2 leading-tight mb-2">{record.title}</h3>
+                <h3 className="font-semibold text-base text-gray-800 line-clamp-2 leading-tight mb-2">
+                  {record.title.length > 30 ? `${record.title.substring(0, 30)}...` : record.title}
+                </h3>
                 
                 {/* 読んだ量 */}
                 <div className="flex items-center space-x-2 mb-2">

--- a/frontend/src/components/Timeline.tsx
+++ b/frontend/src/components/Timeline.tsx
@@ -214,7 +214,12 @@ function Timeline() {
               <div className="mb-4">
                 {/* 書籍タイトル */}
                 <h3 className="font-semibold text-base text-gray-800 line-clamp-2 leading-tight mb-2">
-                  {record.title.length > 30 ? `${record.title.substring(0, 30)}...` : record.title}
+                  <span className="sm:hidden">
+                    {record.title.length > 30 ? `${record.title.substring(0, 30)}...` : record.title}
+                  </span>
+                  <span className="hidden sm:block">
+                    {record.title}
+                  </span>
                 </h3>
                 
                 {/* 読んだ量 */}

--- a/frontend/src/components/Timeline.tsx
+++ b/frontend/src/components/Timeline.tsx
@@ -211,17 +211,19 @@ function Timeline() {
               className="bg-white rounded-xl shadow-md border border-orange-100 p-6 hover:shadow-lg transition-shadow"
             >
               {/* ヘッダー */}
-              <div className="flex items-start justify-between mb-4">
-                <div className="flex items-center space-x-3">
-                  <span className="text-2xl">{getReadingAmountIcon(record.reading_amount)}</span>
-                  <div className="flex-1 min-w-0">
-                    <h3 className="font-semibold text-lg text-gray-800 line-clamp-2 leading-tight">{record.title}</h3>
-                    <p className="text-sm text-gray-500">{formatDate(record.created_at)}</p>
-                  </div>
+              <div className="mb-4">
+                {/* 書籍タイトル */}
+                <h3 className="font-semibold text-lg text-gray-800 line-clamp-2 leading-tight mb-2">{record.title}</h3>
+                
+                {/* 読んだ量 */}
+                <div className="flex items-center space-x-2 mb-2">
+                  <span className="text-xl">{getReadingAmountIcon(record.reading_amount)}</span>
+                  <span className="text-sm text-gray-600">{record.reading_amount}</span>
+                  <div className={`w-3 h-3 rounded-full ${getReadingAmountColor(record.reading_amount)} flex-shrink-0`}></div>
                 </div>
-                <div className="flex items-center space-x-2">
-                  <div className={`w-4 h-4 rounded-full ${getReadingAmountColor(record.reading_amount)} flex-shrink-0`}></div>
-                  {/* いいねボタン */}
+                
+                {/* いいねボタン */}
+                <div className="mb-2">
                   <button
                     onClick={() => handleLike(record.id, record.is_liked || false)}
                     className={`flex items-center space-x-1 px-3 py-1 rounded-full text-sm font-medium transition-colors ${
@@ -236,6 +238,9 @@ function Timeline() {
                     <span>{Number(record.like_count ?? 0)}</span>
                   </button>
                 </div>
+                
+                {/* 登録日 */}
+                <p className="text-sm text-gray-500">{formatDate(record.created_at)}</p>
               </div>
 
               {/* リンク */}

--- a/frontend/src/components/Timeline.tsx
+++ b/frontend/src/components/Timeline.tsx
@@ -214,8 +214,8 @@ function Timeline() {
               <div className="flex items-start justify-between mb-4">
                 <div className="flex items-center space-x-3">
                   <span className="text-2xl">{getReadingAmountIcon(record.reading_amount)}</span>
-                  <div>
-                    <h3 className="font-semibold text-lg text-gray-800">{record.title}</h3>
+                  <div className="flex-1 min-w-0">
+                    <h3 className="font-semibold text-lg text-gray-800 line-clamp-2 leading-tight">{record.title}</h3>
                     <p className="text-sm text-gray-500">{formatDate(record.created_at)}</p>
                   </div>
                 </div>

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -17,3 +17,12 @@ body {
   min-width: 320px;
   min-height: 100vh;
 }
+
+/* カスタムユーティリティクラス */
+.line-clamp-2 {
+  display: -webkit-box;
+  -webkit-line-clamp: 2;
+  -webkit-box-orient: vertical;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}


### PR DESCRIPTION
## 概要

イシュー #62 の対応として、書籍名の表示を最適化しました。

## 変更内容

### 📱 レイアウトの改善
- 書籍タイトル、読んだ量、いいね、登録日を上から順番に表示
- 横並びから縦並びレイアウトに変更
- 書籍タイトルの表示エリアを大幅に拡大

### 📏 文字制限の実装
- 書籍タイトルを2行制限に設定
- 2行を超える場合は「...」で省略
- 30文字閾値を設定（モバイルのみ）

### 🖥️ レスポンシブ対応
- モバイル: 30文字制限で省略表示
- PC: 書籍名を全表示

## 修正ファイル
- frontend/src/components/MyPage.tsx
- frontend/src/components/Timeline.tsx
- frontend/src/index.css

Closes #62