### PR TITLE
feat: シェア機能の文字数閾値を500文字に変更

### DIFF
--- a/frontend/src/components/MyPage.tsx
+++ b/frontend/src/components/MyPage.tsx
@@ -192,9 +192,9 @@ function MyPage() {
     return combinedText;
   };
 
-  // 文字数チェック（140文字以内かどうか）
+  // 文字数チェック（500文字以内かどうか）
   const isWithinLimit = (text: string) => {
-    return text.length <= 140;
+    return text.length <= 500;
   };
 
   // X（Twitter）でシェア

--- a/frontend/src/components/QAPage.tsx
+++ b/frontend/src/components/QAPage.tsx
@@ -48,7 +48,7 @@ function QAPage() {
                   <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M8.684 13.342C8.886 12.938 9 12.482 9 12c0-.482-.114-.938-.316-1.342m0 2.684a3 3 0 110-2.684m0 2.684l6.632 3.316m-6.632-6l6.632-3.316m0 0a3 3 0 105.367-2.684 3 3 0 00-5.367 2.684zm0 9.316a3 3 0 105.367 2.684 3 3 0 00-5.367-2.684z" />
                 </svg>
               </span>
-              <span><b>Xでシェア / noteのネタに</b>：学び・アクション内容をSNSでシェアできます。140文字以内ならX（旧Twitter）、超過時はnoteのネタとして利用できます。140文字以内なら青色、超過時は緑色で表示されます。</span>
+              <span><b>Xでシェア / noteのネタに</b>：学び・アクション内容をSNSでシェアできます。500文字以内ならX（旧Twitter）、超過時はnoteのネタとして利用できます。500文字以内なら青色、超過時は緑色で表示されます。</span>
             </li>
             <li className="flex items-start">
               <span className="mr-2">


### PR DESCRIPTION
## 概要

GitHub Issue #61 の対応として、シェア機能のXとnoteの文字数閾値を140文字から500文字に変更しました。

## 変更内容

### 1. シェア機能の文字数制限変更
- **変更前**: 140文字以内でX、超過時はnote
- **変更後**: 500文字以内でX、超過時はnote

### 2. 修正対象ファイル
- : 関数の閾値を500文字に変更
- : シェア機能説明の文字数制限を500文字に更新

### 3. 技術的な変更
- 関数:  → 
- コメント更新: 「140文字以内かどうか」→「500文字以内かどうか」
- QAページの説明文更新

## 検討事項
Issue #61で記載されている通り、X無料ユーザーを想定し、140文字区切りを文章中に付与することは検討したが、X有料ユーザーが本サービスのスコープであった場合に不要な機能になるため実装しませんでした。

## テスト項目
- [x] 500文字以内のテキストでXシェアが動作することを確認
- [x] 500文字を超えるテキストでnoteシェアが動作することを確認
- [x] シェアボタンの色が正しく切り替わることを確認
- [x] QAページの説明が正しく更新されていることを確認

## 関連Issue

Closes #61