### PR TITLE
Issue #66: 読書記録登録後にマイページに遷移する機能を追加

### DIFF
--- a/frontend/src/components/InputForm.tsx
+++ b/frontend/src/components/InputForm.tsx
@@ -1,4 +1,5 @@
-import { useState, useRef, useEffect } from 'react';
+import { useEffect, useRef, useState } from 'react';
+import { useNavigate } from 'react-router-dom';
 import { trackError, trackPostCreation } from '../utils/analytics';
 import BookIcon from './BookIcon';
 
@@ -13,6 +14,7 @@ interface FormData {
 }
 
 function InputForm() {
+  const navigate = useNavigate();
   const [formData, setFormData] = useState<FormData>({
     title: '',
     readingAmount: '',
@@ -274,8 +276,10 @@ function InputForm() {
       }
       
       // 成功時の処理
-      alert('投稿が完了しました！');
+      alert('投稿が完了しました！マイページに遷移します。');
       resetForm();
+      // マイページに遷移
+      navigate('/mypage');
     } catch (error) {
       console.error('送信エラー:', error);
       trackError('post_creation_failed', error instanceof Error ? error.message : 'Unknown error');


### PR DESCRIPTION
## 概要

GitHub Issue #66の対応として、読書記録登録後にマイページに遷移する機能を追加しました。

## 変更内容

### 機能追加
- 投稿成功後の遷移: 読書記録登録成功後に自動的にマイページに遷移
- ユーザー体験の向上: 投稿完了をユーザーに明確に認識させる

### 修正対象ファイル
- frontend/src/components/InputForm.tsx

### 技術的変更
- useNavigateフックを追加
- 投稿成功時の処理にnavigate('/mypage')を追加
- アラートメッセージを「投稿が完了しました！マイページに遷移します。」に変更

## 動作確認
1. 読書記録を入力して投稿
2. 投稿成功後、アラートが表示される
3. 自動的にマイページに遷移
4. 投稿した記録がマイページに表示される

## 関連Issue
Closes #66

## ツイート用広報内容

### 機能改善のお知らせ 📚✨

🎯 1段読書アプリのユーザー体験が改善されました！

✨ 機能改修
読書記録登録後にマイページに自動遷移
投稿完了をユーザーに明確に認識させる
よりスムーズな操作フローを実現

✏️ 使い方
読書記録を入力して投稿
投稿成功後、自動的にマイページに遷移
投稿した記録をすぐに確認可能

より快適な読書体験を提供します！📖💡

#1段読書 #読書習慣 #読書アプリ #学びの共有 #読書コミュニティ