### PR TITLE
Issue #67: 書籍じゃありませんボタンの改修

### DIFF
--- a/frontend/src/components/InputForm.tsx
+++ b/frontend/src/components/InputForm.tsx
@@ -353,7 +353,7 @@ function InputForm() {
               name="title"
               value={formData.title}
               onChange={handleInputChange}
-              placeholder="https://www.amazon.co.jp/dp/XXXXXXXXXX"
+              placeholder={formData.isNotBook ? "書籍以外のURLを入力して下さい。ex. Web記事" : "https://www.amazon.co.jp/dp/XXXXXXXXXX"}
               className="w-full px-4 py-3 border border-gray-300 rounded-lg focus:ring-2 focus:ring-orange-500 focus:border-transparent transition-colors"
               required
             />
@@ -382,7 +382,7 @@ function InputForm() {
                   : 'bg-gray-100 border-gray-300 text-gray-700 hover:bg-gray-200'
               }`}
             >
-              {formData.isNotBook ? '✓ 書籍じゃありません' : '📚 書籍じゃありません'}
+              {formData.isNotBook ? '✓ not 書籍' : '📚 not 書籍'}
             </button>
             <span className="text-xs text-gray-500">
               （記事、ブログ、YouTubeなど書籍以外の場合はチェックしてください）


### PR DESCRIPTION
## 概要

GitHub Issue #67の対応として、書籍じゃありませんボタンの改修を実施しました。

## 変更内容

### UI改善
- ボタン表記の変更: 「書籍じゃありません」→「not 書籍」
- よりコンパクトでクールな見た目に改善

### 機能改善
- 動的プレースホルダー: 「not 書籍」ボタン押下時にプレースホルダーが変更
- 書籍モード: 「https://www.amazon.co.jp/dp/XXXXXXXXXX」
- 書籍以外モード: 「書籍以外のURLを入力して下さい。ex. Web記事」

### 修正対象ファイル
- frontend/src/components/InputForm.tsx

### 技術的変更
- プレースホルダーを条件分岐で動的に変更
- ボタンテキストを「not 書籍」に統一

## 動作確認
1. 初期状態: ボタンに「📚 not 書籍」と表示
2. ボタン押下: ボタンに「✓ not 書籍」と表示、プレースホルダーが変更
3. 再度押下: 元の状態に戻る

## 関連Issue
Closes #67

## ツイート用広報内容

### 機能改善のお知らせ 📚✨

🎯 1段読書アプリのUIが改善されました！

✨ 機能改修
・書籍じゃありませんボタンの表記を「not 書籍」に変更
・よりコンパクトでクールな見た目に改善
・動的プレースホルダーで入力ガイドを改善

✏️ 使い方
・「not 書籍」ボタンを押下すると入力ガイドが変更
・書籍以外のコンテンツも簡単に入力可能
・より直感的な操作フローを実現

より使いやすい読書アプリになりました！📖💡

#1段読書 #読書習慣 #読書アプリ #学びの共有 #読書コミュニティ