### PR TITLE
hotfix: 本番環境用ネタバレ機能マイグレーションSQL

### DIFF
--- a/production-migration-spoiler-fields.sql
+++ b/production-migration-spoiler-fields.sql
@@ -1,0 +1,32 @@
+-- 本番環境用：ネタバレ関連のカラムとテーブルを追加するマイグレーション
+-- 実行日時: 2025-07-26
+-- 実行環境: Supabase本番環境
+
+-- reading_recordsテーブルに新しいカラムを追加
+ALTER TABLE reading_records 
+ADD COLUMN IF NOT EXISTS notes TEXT,
+ADD COLUMN IF NOT EXISTS is_not_book BOOLEAN DEFAULT FALSE,
+ADD COLUMN IF NOT EXISTS custom_link TEXT,
+ADD COLUMN IF NOT EXISTS contains_spoiler BOOLEAN DEFAULT FALSE;
+
+-- user_settingsテーブルを作成
+CREATE TABLE IF NOT EXISTS user_settings (
+    id SERIAL PRIMARY KEY,
+    user_id VARCHAR(255) NOT NULL UNIQUE,
+    hide_spoilers BOOLEAN DEFAULT FALSE,
+    created_at TIMESTAMP WITH TIME ZONE DEFAULT CURRENT_TIMESTAMP,
+    updated_at TIMESTAMP WITH TIME ZONE DEFAULT CURRENT_TIMESTAMP
+);
+
+-- user_settingsテーブルのインデックスを作成
+CREATE INDEX IF NOT EXISTS idx_user_settings_user_id ON user_settings(user_id);
+
+-- user_settingsテーブルの更新日時トリガーを作成
+CREATE TRIGGER update_user_settings_updated_at 
+    BEFORE UPDATE ON user_settings 
+    FOR EACH ROW 
+    EXECUTE FUNCTION update_updated_at_column();
+
+-- 実行確認用クエリ
+-- SELECT column_name, data_type FROM information_schema.columns WHERE table_name = 'reading_records' AND column_name IN ('notes', 'is_not_book', 'custom_link', 'contains_spoiler');
+-- SELECT * FROM user_settings LIMIT 5; 


### PR DESCRIPTION
## 概要

本番環境のSupabaseでネタバレ機能を動作させるためのデータベースマイグレーションSQLを追加しました。

## 追加内容

### 新規ファイル
・ - 本番環境用マイグレーションSQL

### マイグレーション内容

**reading_recordsテーブルの変更**:
・ - 備考・メモ用のTEXTカラム
・ - 書籍以外のコンテンツかどうかのフラグ
・ - カスタムリンク用のTEXTカラム
・ - ネタバレを含むかどうかのフラグ

**user_settingsテーブルの新規作成**:
・ユーザーごとの設定を管理
・ - ネタバレ非表示設定
・ユニーク制約とインデックスを設定
・更新日時の自動更新トリガーを設定

## 実行手順

1. Supabaseダッシュボードにアクセス
2. SQL Editorを開く
3. の内容をコピー&ペースト
4. 実行ボタンをクリック

## 実行後の確認

以下の機能が本番環境で動作するようになります：
・✅ 入力画面でのネタバレ設定
・✅ マイページでのネタバレ設定編集
・✅ 設定画面でのネタバレ非表示設定
・✅ タイムラインでのネタバレ投稿フィルタリング

## 注意事項

・このマイグレーションは本番環境専用です
・開発環境では既に適用済みです
・実行前にバックアップを推奨します

---

## ツイート広報内容

本番環境アップデートのお知らせ 📚✨

🎯 1段読書アプリのネタバレ機能が本番環境で利用可能になりました！

✨ 新機能
・投稿時にネタバレ設定を選択可能
・マイページで既存投稿のネタバレ設定を変更
・設定画面でネタバレ投稿の表示/非表示を制御
・タイムラインでネタバレ投稿を自動フィルタリング

より快適な読書体験をシェアしましょう！📖💡

#1段読書 #読書習慣 #読書アプリ #ネタバレ設定 #読書コミュニティ