### PR TITLE
feat: 過去読んだものから登録する機能を実装 (Issue #86)

### DIFF
--- a/backend/src/database.ts
+++ b/backend/src/database.ts
@@ -230,7 +230,7 @@ export const getUserReadingRecords = async (userId: string, sessionId?: string) 
 export const searchReadingRecordsByTitle = async (searchTerm: string, limit: number = 10) => {
   try {
     const query = `
-      SELECT DISTINCT title, link, is_not_book, custom_link
+      SELECT DISTINCT title, link, is_not_book, custom_link, created_at
       FROM reading_records 
       WHERE title ILIKE $1
       ORDER BY created_at DESC

--- a/backend/src/database.ts
+++ b/backend/src/database.ts
@@ -226,6 +226,24 @@ export const getUserReadingRecords = async (userId: string, sessionId?: string) 
   }
 };
 
+// 過去の読書記録をタイトルで検索
+export const searchReadingRecordsByTitle = async (searchTerm: string, limit: number = 10) => {
+  try {
+    const query = `
+      SELECT DISTINCT title, link, is_not_book, custom_link
+      FROM reading_records 
+      WHERE title ILIKE $1
+      ORDER BY created_at DESC
+      LIMIT $2
+    `;
+    const result = await pool.query(query, [`%${searchTerm}%`, limit]);
+    return { success: true, data: result.rows };
+  } catch (error) {
+    console.error('Search reading records error:', error);
+    return { success: false, error: error instanceof Error ? error.message : 'Unknown error' };
+  }
+};
+
 // ユーザー設定の型定義
 export interface UserSettings {
   id?: number;

--- a/backend/src/database.ts
+++ b/backend/src/database.ts
@@ -230,10 +230,10 @@ export const getUserReadingRecords = async (userId: string, sessionId?: string) 
 export const searchReadingRecordsByTitle = async (searchTerm: string, limit: number = 10) => {
   try {
     const query = `
-      SELECT DISTINCT title, link, is_not_book, custom_link, created_at
+      SELECT DISTINCT ON (title) title, link, is_not_book, custom_link, created_at
       FROM reading_records 
       WHERE title ILIKE $1
-      ORDER BY created_at DESC
+      ORDER BY title, created_at DESC
       LIMIT $2
     `;
     const result = await pool.query(query, [`%${searchTerm}%`, limit]);

--- a/backend/src/index.ts
+++ b/backend/src/index.ts
@@ -12,6 +12,7 @@ import {
     getUserSettings,
     ReadingRecord,
     removeLike,
+    searchReadingRecordsByTitle,
     testConnection,
     updateReadingRecord,
     upsertUserSettings
@@ -459,6 +460,37 @@ app.get('/api/reading-records/:id', async (req, res) => {
   } catch (error) {
     res.status(500).json({ 
       message: 'Error retrieving reading record', 
+      error: error instanceof Error ? error.message : 'Unknown error' 
+    });
+  }
+});
+
+// 過去の読書記録をタイトルで検索
+app.get('/api/reading-records/search/title', async (req, res) => {
+  try {
+    const { q, limit = 10 } = req.query;
+    
+    if (!q || typeof q !== 'string') {
+      return res.status(400).json({ message: 'Search query is required' });
+    }
+
+    const searchLimit = parseInt(limit as string) || 10;
+    const result = await searchReadingRecordsByTitle(q, searchLimit);
+    
+    if (result.success) {
+      res.json({ 
+        message: 'Search completed successfully', 
+        data: result.data 
+      });
+    } else {
+      res.status(500).json({ 
+        message: 'Failed to search reading records', 
+        error: result.error 
+      });
+    }
+  } catch (error) {
+    res.status(500).json({ 
+      message: 'Error searching reading records', 
       error: error instanceof Error ? error.message : 'Unknown error' 
     });
   }

--- a/frontend/src/components/InputForm.tsx
+++ b/frontend/src/components/InputForm.tsx
@@ -199,11 +199,6 @@ function InputForm() {
       customLink: book.custom_link || ''
     }));
     
-    // 書籍ではない場合で、Amazonリンクが含まれている場合は自動取得
-    if (book.is_not_book && book.custom_link && isAmazonLink(book.custom_link)) {
-      extractTitleFromAmazonLink(book.custom_link);
-    }
-    
     // 検索結果をクリア
     setPastBooksSearchResults([]);
     setPastBooksSearchTerm('');


### PR DESCRIPTION
## 概要
過去に読んだ書籍や記事をタイトル検索で登録できる機能を実装しました。

## 変更内容

### バックエンド
- **データベース関数の追加** (`backend/src/database.ts`)
  - `searchReadingRecordsByTitle`: タイトルで部分一致検索を行う関数
  - `DISTINCT ON (title)`を使用して重複タイトルを一つだけ表示

- **APIエンドポイントの追加** (`backend/src/index.ts`)
  - `GET /api/reading-records/search/title`: 過去の読書記録を検索するエンドポイント
  - クエリパラメータ: `q` (検索語), `limit` (結果数制限)

### フロントエンド
- **状態管理の追加** (`frontend/src/components/InputForm.tsx`)
  - 過去読んだもの検索用の状態変数
  - 検索結果の管理
  - ローディング状態の管理

- **検索機能の実装**
  - `searchPastBooks`: バックエンドAPIを呼び出して検索
  - `selectPastBook`: 検索結果から選択してフォームに自動入力
  - `handlePastBooksSearchChange`: 検索入力の変更ハンドラー

- **UIコンポーネントの追加**
  - 「過去読んだものから登録する」アコーディオン
  - 検索入力フィールド（プレースホルダー: "例：How Google Works"）
  - 検索結果の表示（書籍/記事の区別表示）
  - ローディングインジケーター

- **パフォーマンス最適化**
  - デバウンス処理（500ms）でAPI呼び出しを最適化
  - クリーンアップ処理でメモリリークを防止

## 機能の動作
1. not書籍ボタンの下に「過去読んだものから登録する」アコーディオンが表示
2. アコーディオンを開くと検索入力フィールドが表示
3. タイトルを入力すると部分一致で過去の読書記録を検索
4. 検索結果から選択すると、タイトルと書籍/記事の種類が自動入力
5. 重複したタイトルは一つだけ表示される

## 技術的な修正
- PostgreSQLの`DISTINCT ON`構文を使用して重複タイトルを制御
- `DISTINCT`と`ORDER BY`の組み合わせエラーを修正

## テスト
- 「USJ」で検索して過去の読書記録が表示されることを確認
- 重複タイトルが一つだけ表示されることを確認
- 検索結果から選択してフォームに自動入力されることを確認