### PR TITLE
fix: Issue #103 - dev@example.com認証エラーとダミーデータ問題を修正

### DIFF
--- a/backend/src/auth.ts
+++ b/backend/src/auth.ts
@@ -10,7 +10,7 @@ const googleClient = new OAuth2Client(GOOGLE_CLIENT_ID);
 // JWTトークンの生成
 export const generateToken = (userId: string, email: string): string => {
   return jwt.sign(
-    { userId, email },
+    { userId, email, sub: userId },
     JWT_SECRET,
     { expiresIn: '7d' }
   );
@@ -55,15 +55,23 @@ export const authenticateToken = (req: any, res: any, next: any) => {
   const authHeader = req.headers['authorization'];
   const token = authHeader && authHeader.split(' ')[1];
 
+  console.log('Auth Debug - Authorization header:', authHeader);
+  console.log('Auth Debug - Extracted token:', token ? 'Token exists' : 'No token');
+
   if (!token) {
+    console.log('Auth Debug - No token provided');
     return res.status(401).json({ message: 'Access token required' });
   }
 
   const decoded = verifyToken(token);
+  console.log('Auth Debug - Decoded token:', decoded);
+  
   if (!decoded) {
+    console.log('Auth Debug - Invalid token');
     return res.status(403).json({ message: 'Invalid token' });
   }
 
   req.user = decoded;
+  console.log('Auth Debug - User set to req.user:', req.user);
   next();
 }; 

--- a/frontend/src/components/InputForm.tsx
+++ b/frontend/src/components/InputForm.tsx
@@ -1,6 +1,7 @@
 import { useEffect, useRef, useState } from 'react';
 import { useNavigate } from 'react-router-dom';
 import { trackError, trackPostCreation } from '../utils/analytics';
+import { useAuth } from '../contexts/AuthContext';
 import BookIcon from './BookIcon';
 
 interface FormData {
@@ -16,6 +17,7 @@ interface FormData {
 
 function InputForm() {
   const navigate = useNavigate();
+  const { token, isAuthenticated } = useAuth();
   const [formData, setFormData] = useState<FormData>({
     title: '',
     readingAmount: '',
@@ -410,6 +412,12 @@ function InputForm() {
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault();
     
+    // 認証チェック
+    if (!isAuthenticated || !token) {
+      alert('ログインが必要です。ログインしてから再度お試しください。');
+      return;
+    }
+    
     // 書籍の場合、タイトルが適切に取得されているかチェック
     if (!formData.isNotBook && !isValidBookTitle(formData.title)) {
       alert('書籍タイトルが正しく取得されていません。Amazonリンクから書籍タイトルが自動取得されるまでお待ちください。');
@@ -438,6 +446,7 @@ function InputForm() {
         method: 'POST',
         headers: {
           'Content-Type': 'application/json',
+          'Authorization': `Bearer ${token}`,
         },
         body: JSON.stringify({
           title: formData.title,

--- a/frontend/src/components/MyPage.tsx
+++ b/frontend/src/components/MyPage.tsx
@@ -2,6 +2,7 @@ import { useEffect, useState } from 'react';
 import { isAmazonLink } from '../utils/amazonUtils';
 import { trackShare } from '../utils/analytics';
 import { useExpandableText } from '../hooks/useExpandableText';
+import { useAuth } from '../contexts/AuthContext';
 import BookIcon from './BookIcon';
 import ExpandableTextDisplay from './ExpandableTextDisplay';
 
@@ -23,6 +24,7 @@ interface ReadingRecord {
 
 
 function MyPage() {
+  const { token, isAuthenticated } = useAuth();
   const [records, setRecords] = useState<ReadingRecord[]>([]);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
@@ -63,9 +65,16 @@ function MyPage() {
 
   useEffect(() => {
     fetchRecords();
-  }, []);
+  }, [isAuthenticated, token]);
 
   const fetchRecords = async () => {
+    // 認証チェック
+    if (!isAuthenticated || !token) {
+      setError('ログインが必要です。');
+      setLoading(false);
+      return;
+    }
+
     try {
       setLoading(true);
       // 環境変数からAPI URLを取得
@@ -73,6 +82,7 @@ function MyPage() {
       const response = await fetch(`${API_BASE_URL}/api/my-records`, {
         headers: {
           'Content-Type': 'application/json',
+          'Authorization': `Bearer ${token}`,
         },
       });
       
@@ -101,6 +111,12 @@ function MyPage() {
 
   // 投稿削除処理
   const deleteRecord = async (id: number, title: string) => {
+    // 認証チェック
+    if (!isAuthenticated || !token) {
+      alert('ログインが必要です。');
+      return;
+    }
+
     // 削除確認
     if (!window.confirm(`「${title}」を削除しますか？この操作は取り消せません。`)) {
       return;
@@ -112,6 +128,7 @@ function MyPage() {
         method: 'DELETE',
         headers: {
           'Content-Type': 'application/json',
+          'Authorization': `Bearer ${token}`,
         },
       });
 
@@ -171,6 +188,12 @@ function MyPage() {
 
   // 投稿更新処理
   const updateRecord = async (id: number) => {
+    // 認証チェック
+    if (!isAuthenticated || !token) {
+      alert('ログインが必要です。');
+      return;
+    }
+
     try {
       console.log('=== 更新処理開始 ===');
       console.log('更新対象ID:', id);
@@ -186,6 +209,7 @@ function MyPage() {
         method: 'PUT',
         headers: {
           'Content-Type': 'application/json',
+          'Authorization': `Bearer ${token}`,
         },
         body: requestBody,
       });


### PR DESCRIPTION
## 概要
Issue #103で報告された本番環境での`dev@example.com`使用問題および関連する認証エラーを修正しました。

## 修正内容

### 1. バックエンド認証修正
- **POST /api/reading-records**に`authenticateToken`ミドルウェア追加
- **GET /api/my-records**に`authenticateToken`ミドルウェア追加  
- ダミーユーザー情報（`dev@example.com`, `dev-user-123`）を実際の認証情報に置き換え
- JWTトークン生成時に`sub`フィールドを追加（Google認証との互換性向上）
- 認証ミドルウェアにデバッグログを追加

### 2. フロントエンド認証修正
- **InputForm.tsx**に`AuthContext`を追加してトークンベース認証を実装
- **MyPage.tsx**に`AuthContext`を追加してトークンベース認証を実装
- 全てのAPI呼び出しに`Authorization: Bearer {token}`ヘッダーを追加
- 投稿・取得・編集・削除機能に認証チェック処理を追加
- useEffectの依存配列に認証状態を追加

## 解決した問題
- ✅ 本番環境で`dev@example.com`が使用される問題
- ✅ 読書記録投稿時の401認証エラー
- ✅ マイページでの401認証エラー
- ✅ 認証されたユーザー情報が正しくデータベースに保存されない問題

## 影響範囲
- 📝 読書記録投稿機能
- 📖 マイページ表示機能
- ✏️ 投稿編集機能
- 🗑️ 投稿削除機能

## テスト結果
- Docker開発環境での動作確認済み
- 認証フローの正常動作確認済み
- API呼び出しでの適切なトークン送信確認済み

## 追加情報
本修正により、今後新規投稿は全て認証されたユーザーの実際のメールアドレスで保存されます。
既存の`dev@example.com`データについては別途データクリーンアップが必要です。

Fixes #103