### PR TITLE
hotfix: Dashboard認証エラー緊急修正

### DIFF
--- a/frontend/src/components/Dashboard.tsx
+++ b/frontend/src/components/Dashboard.tsx
@@ -1,5 +1,6 @@
 import { useEffect, useState } from 'react';
 import { CartesianGrid, Line, LineChart, ResponsiveContainer, Tooltip, XAxis, YAxis } from 'recharts';
+import { useAuth } from '../contexts/AuthContext';
 import BookIcon from './BookIcon';
 
 interface ReadingRecord {
@@ -22,6 +23,7 @@ interface DailyRecord {
 }
 
 function Dashboard() {
+  const { token, isAuthenticated } = useAuth();
   const [records, setRecords] = useState<ReadingRecord[]>([]);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
@@ -29,9 +31,16 @@ function Dashboard() {
 
   useEffect(() => {
     fetchRecords();
-  }, []);
+  }, [isAuthenticated, token]);
 
   const fetchRecords = async () => {
+    // 認証チェック
+    if (!isAuthenticated || !token) {
+      setError('ログインが必要です。');
+      setLoading(false);
+      return;
+    }
+
     try {
       setLoading(true);
       // 環境変数からAPI URLを取得
@@ -39,6 +48,7 @@ function Dashboard() {
       const response = await fetch(`${API_BASE_URL}/api/my-records`, {
         headers: {
           'Content-Type': 'application/json',
+          'Authorization': `Bearer ${token}`,
         },
       });
       


### PR DESCRIPTION
## 🚨 緊急修正: Dashboard認証エラー

本番環境でダッシュボード機能が401認証エラーで動作しない問題を緊急修正しました。

## 🐛 発生していた問題
```
GET https://ichidan-dokusho-v2.onrender.com/api/my-records 401 (Unauthorized)
```

## 🔍 原因
Dashboard.tsxで`AuthContext`が使用されておらず、認証トークンがAPI呼び出しに含まれていませんでした。

## ✅ 修正内容

### Dashboard.tsx
- `AuthContext`をインポートして認証機能を追加
- `useAuth()`フックでトークンと認証状態を取得
- API呼び出しに`Authorization: Bearer {token}`ヘッダーを追加
- 認証チェック処理を追加
- useEffectの依存配列に認証状態を追加

## 🧪 動作確認
- ✅ TypeScriptビルド成功
- ✅ Viteビルド成功
- ✅ 認証フローの実装確認済み

## 📋 影響範囲
- 📊 ダッシュボード機能（読書記録の統計表示）
- 📈 グラフ表示機能

## 🚀 期待される効果
- 本番環境でダッシュボードが正常に動作
- 認証されたユーザーの読書記録が正しく表示
- 401エラーの解消

## ⚡ 緊急度
- **High Priority**: 本番環境でダッシュボード機能が完全に使用不可のため

## 🔗 関連Issue
Issue #103のフォローアップ修正