### PR TITLE
feat: Issue #115対応 - 書きたいテーマ設定機能を実装（10テーマ制限付き）

### DIFF
--- a/backend/migration-add-writing-themes.sql
+++ b/backend/migration-add-writing-themes.sql
@@ -1,0 +1,25 @@
+-- 書きたいテーマテーブルの作成
+CREATE TABLE IF NOT EXISTS writing_themes (
+    id SERIAL PRIMARY KEY,
+    user_id VARCHAR(255) NOT NULL,
+    theme_name VARCHAR(100) NOT NULL,
+    created_at TIMESTAMP WITH TIME ZONE DEFAULT CURRENT_TIMESTAMP,
+    updated_at TIMESTAMP WITH TIME ZONE DEFAULT CURRENT_TIMESTAMP
+);
+
+-- インデックスの作成
+CREATE INDEX IF NOT EXISTS idx_writing_themes_user_id ON writing_themes(user_id);
+CREATE INDEX IF NOT EXISTS idx_writing_themes_created_at ON writing_themes(created_at);
+
+-- 更新日時を自動更新するトリガーの作成
+CREATE TRIGGER update_writing_themes_updated_at 
+    BEFORE UPDATE ON writing_themes 
+    FOR EACH ROW 
+    EXECUTE FUNCTION update_updated_at_column();
+
+-- サンプルデータの挿入（テスト用）
+INSERT INTO writing_themes (user_id, theme_name) VALUES
+('dev-user-123', 'キャリア'),
+('dev-user-123', 'サウナ'),
+('dev-user-123', 'プログラミング')
+ON CONFLICT DO NOTHING;

--- a/frontend/src/components/SettingsPage.tsx
+++ b/frontend/src/components/SettingsPage.tsx
@@ -5,18 +5,31 @@ interface UserSettings {
   hideSpoilers: boolean;
 }
 
+interface WritingTheme {
+  id: number;
+  user_id: string;
+  theme_name: string;
+  created_at: string;
+  updated_at: string;
+}
+
 function SettingsPage() {
   const { user, token } = useAuth();
   const [settings, setSettings] = useState<UserSettings>({
     hideSpoilers: false
   });
+  const [themes, setThemes] = useState<WritingTheme[]>([]);
+  const [newTheme, setNewTheme] = useState('');
+  const [editingTheme, setEditingTheme] = useState<{ id: number; name: string } | null>(null);
   const [loading, setLoading] = useState(true);
   const [saving, setSaving] = useState(false);
+  const [themeLoading, setThemeLoading] = useState(false);
   const [message, setMessage] = useState('');
 
   useEffect(() => {
     if (user) {
       loadSettings();
+      loadThemes();
     }
   }, [user]);
 
@@ -73,11 +86,165 @@ function SettingsPage() {
     }
   };
 
+  const loadThemes = async () => {
+    try {
+      const API_BASE_URL = import.meta.env.VITE_API_BASE_URL || 'http://localhost:3001';
+      const response = await fetch(`${API_BASE_URL}/api/writing-themes`, {
+        headers: {
+          'Authorization': `Bearer ${token}`,
+        },
+      });
+
+      if (response.ok) {
+        const result = await response.json();
+        setThemes(result.data || []);
+      } else {
+        console.error('テーマの読み込みに失敗しました');
+        setThemes([]);
+      }
+    } catch (error) {
+      console.error('テーマの読み込みに失敗しました:', error);
+      setThemes([]);
+    }
+  };
+
   const handleSettingChange = (key: keyof UserSettings, value: boolean) => {
     setSettings(prev => ({
       ...prev,
       [key]: value
     }));
+  };
+
+  const addTheme = async () => {
+    if (!newTheme.trim()) {
+      setMessage('テーマ名を入力してください');
+      return;
+    }
+
+    if (newTheme.length > 100) {
+      setMessage('テーマ名は100文字以内で入力してください');
+      return;
+    }
+
+    if (themes.length >= 10) {
+      setMessage('テーマは最大10個まで設定できます。新しいテーマを追加するには、既存のテーマを削除してください。');
+      return;
+    }
+
+    setThemeLoading(true);
+    setMessage('');
+
+    try {
+      const API_BASE_URL = import.meta.env.VITE_API_BASE_URL || 'http://localhost:3001';
+      const response = await fetch(`${API_BASE_URL}/api/writing-themes`, {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+          'Authorization': `Bearer ${token}`,
+        },
+        body: JSON.stringify({ theme_name: newTheme.trim() }),
+      });
+
+      if (response.ok) {
+        setNewTheme('');
+        await loadThemes();
+        setMessage('テーマを追加しました');
+        setTimeout(() => setMessage(''), 3000);
+      } else {
+        const errorData = await response.json();
+        setMessage(errorData.message || 'テーマの追加に失敗しました');
+      }
+    } catch (error) {
+      console.error('テーマの追加に失敗しました:', error);
+      setMessage('テーマの追加に失敗しました');
+    } finally {
+      setThemeLoading(false);
+    }
+  };
+
+  const startEditTheme = (theme: WritingTheme) => {
+    setEditingTheme({ id: theme.id, name: theme.theme_name });
+  };
+
+  const cancelEditTheme = () => {
+    setEditingTheme(null);
+  };
+
+  const saveEditTheme = async () => {
+    if (!editingTheme) return;
+
+    if (!editingTheme.name.trim()) {
+      setMessage('テーマ名を入力してください');
+      return;
+    }
+
+    if (editingTheme.name.length > 100) {
+      setMessage('テーマ名は100文字以内で入力してください');
+      return;
+    }
+
+    setThemeLoading(true);
+    setMessage('');
+
+    try {
+      const API_BASE_URL = import.meta.env.VITE_API_BASE_URL || 'http://localhost:3001';
+      const response = await fetch(`${API_BASE_URL}/api/writing-themes/${editingTheme.id}`, {
+        method: 'PUT',
+        headers: {
+          'Content-Type': 'application/json',
+          'Authorization': `Bearer ${token}`,
+        },
+        body: JSON.stringify({ theme_name: editingTheme.name.trim() }),
+      });
+
+      if (response.ok) {
+        setEditingTheme(null);
+        await loadThemes();
+        setMessage('テーマを更新しました');
+        setTimeout(() => setMessage(''), 3000);
+      } else {
+        const errorData = await response.json();
+        setMessage(errorData.message || 'テーマの更新に失敗しました');
+      }
+    } catch (error) {
+      console.error('テーマの更新に失敗しました:', error);
+      setMessage('テーマの更新に失敗しました');
+    } finally {
+      setThemeLoading(false);
+    }
+  };
+
+  const deleteTheme = async (themeId: number, themeName: string) => {
+    if (!window.confirm(`「${themeName}」を削除しますか？この操作は取り消せません。`)) {
+      return;
+    }
+
+    setThemeLoading(true);
+    setMessage('');
+
+    try {
+      const API_BASE_URL = import.meta.env.VITE_API_BASE_URL || 'http://localhost:3001';
+      const response = await fetch(`${API_BASE_URL}/api/writing-themes/${themeId}`, {
+        method: 'DELETE',
+        headers: {
+          'Authorization': `Bearer ${token}`,
+        },
+      });
+
+      if (response.ok) {
+        await loadThemes();
+        setMessage('テーマを削除しました');
+        setTimeout(() => setMessage(''), 3000);
+      } else {
+        const errorData = await response.json();
+        setMessage(errorData.message || 'テーマの削除に失敗しました');
+      }
+    } catch (error) {
+      console.error('テーマの削除に失敗しました:', error);
+      setMessage('テーマの削除に失敗しました');
+    } finally {
+      setThemeLoading(false);
+    }
   };
 
   if (loading) {
@@ -116,6 +283,148 @@ function SettingsPage() {
                   <div className="w-11 h-6 bg-gray-200 peer-focus:outline-none peer-focus:ring-4 peer-focus:ring-orange-300 rounded-full peer peer-checked:after:translate-x-full peer-checked:after:border-white after:content-[''] after:absolute after:top-[2px] after:left-[2px] after:bg-white after:border-gray-300 after:border after:rounded-full after:h-5 after:w-5 after:transition-all peer-checked:bg-orange-500"></div>
                 </label>
               </div>
+            </div>
+          </div>
+
+          {/* 書きたいテーマ設定 */}
+          <div className="mb-8">
+            <div className="flex items-center justify-between mb-4">
+              <h2 className="text-lg font-semibold text-gray-800">書きたいテーマ設定</h2>
+              <div className="text-sm text-gray-500">
+                {themes.length}/10 テーマ
+              </div>
+            </div>
+            <p className="text-sm text-gray-600 mb-2">
+              あなたが書きたいテーマを設定・管理できます。将来的にテーマ別の草稿生成機能で活用されます。
+            </p>
+            <p className="text-xs text-orange-600 mb-4">
+              器用貧乏から抜け出すため、テーマは最大10個まで設定可能です。
+            </p>
+            
+            {/* テーマ追加フォーム */}
+            <div className="mb-6">
+              <div className="flex space-x-2">
+                <input
+                  type="text"
+                  value={newTheme}
+                  onChange={(e) => setNewTheme(e.target.value)}
+                  placeholder="新しいテーマを入力... (例: キャリア、サウナ、プログラミング)"
+                  className="flex-1 px-3 py-2 border border-gray-300 rounded-lg focus:outline-none focus:ring-2 focus:ring-orange-500 focus:border-transparent"
+                  maxLength={100}
+                  onKeyPress={(e) => {
+                    if (e.key === 'Enter') {
+                      addTheme();
+                    }
+                  }}
+                />
+                <button
+                  onClick={addTheme}
+                  disabled={themeLoading || !newTheme.trim() || themes.length >= 10}
+                  className="bg-orange-500 text-white px-4 py-2 rounded-lg hover:bg-orange-600 focus:ring-4 focus:ring-orange-300 transition-colors disabled:opacity-50 disabled:cursor-not-allowed flex items-center space-x-2"
+                >
+                  {themeLoading ? (
+                    <>
+                      <div className="animate-spin rounded-full h-4 w-4 border-b-2 border-white"></div>
+                      <span>追加中...</span>
+                    </>
+                  ) : (
+                    <span>追加</span>
+                  )}
+                </button>
+              </div>
+              <p className="text-xs text-gray-500 mt-1">
+                100文字以内で入力してください
+                {themes.length >= 10 && (
+                  <span className="text-orange-600 block mt-1">
+                    ※ テーマの上限（10個）に達しています。新しいテーマを追加するには既存のテーマを削除してください。
+                  </span>
+                )}
+              </p>
+            </div>
+
+            {/* テーマ一覧 */}
+            <div className="space-y-3">
+              {themes.length === 0 ? (
+                <div className="text-center py-8 text-gray-500">
+                  <p>まだテーマが設定されていません</p>
+                  <p className="text-sm">上記のフォームから新しいテーマを追加してみましょう</p>
+                </div>
+              ) : (
+                themes.map((theme) => (
+                  <div
+                    key={theme.id}
+                    className="border border-gray-200 rounded-lg p-4 hover:shadow-sm transition-shadow"
+                  >
+                    {editingTheme?.id === theme.id ? (
+                      // 編集モード
+                      <div className="space-y-3">
+                        <input
+                          type="text"
+                          value={editingTheme.name}
+                          onChange={(e) => setEditingTheme({ ...editingTheme, name: e.target.value })}
+                          className="w-full px-3 py-2 border border-gray-300 rounded-lg focus:outline-none focus:ring-2 focus:ring-orange-500 focus:border-transparent"
+                          maxLength={100}
+                          onKeyPress={(e) => {
+                            if (e.key === 'Enter') {
+                              saveEditTheme();
+                            } else if (e.key === 'Escape') {
+                              cancelEditTheme();
+                            }
+                          }}
+                        />
+                        <div className="flex space-x-2">
+                          <button
+                            onClick={saveEditTheme}
+                            disabled={themeLoading}
+                            className="bg-blue-500 text-white px-3 py-1 rounded text-sm hover:bg-blue-600 transition-colors disabled:opacity-50"
+                          >
+                            保存
+                          </button>
+                          <button
+                            onClick={cancelEditTheme}
+                            disabled={themeLoading}
+                            className="bg-gray-500 text-white px-3 py-1 rounded text-sm hover:bg-gray-600 transition-colors disabled:opacity-50"
+                          >
+                            キャンセル
+                          </button>
+                        </div>
+                      </div>
+                    ) : (
+                      // 表示モード
+                      <div className="flex items-center justify-between">
+                        <div className="flex-1">
+                          <h3 className="font-medium text-gray-900">{theme.theme_name}</h3>
+                          <p className="text-xs text-gray-500 mt-1">
+                            作成日: {new Date(theme.created_at).toLocaleDateString('ja-JP')}
+                          </p>
+                        </div>
+                        <div className="flex space-x-2">
+                          <button
+                            onClick={() => startEditTheme(theme)}
+                            disabled={themeLoading}
+                            className="text-blue-500 hover:text-blue-700 hover:bg-blue-50 p-2 rounded-full transition-colors disabled:opacity-50"
+                            title="編集"
+                          >
+                            <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                              <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M11 5H6a2 2 0 00-2 2v11a2 2 0 002 2h11a2 2 0 002-2v-5m-1.414-9.414a2 2 0 112.828 2.828L11.828 15H9v-2.828l8.586-8.586z" />
+                            </svg>
+                          </button>
+                          <button
+                            onClick={() => deleteTheme(theme.id, theme.theme_name)}
+                            disabled={themeLoading}
+                            className="text-red-500 hover:text-red-700 hover:bg-red-50 p-2 rounded-full transition-colors disabled:opacity-50"
+                            title="削除"
+                          >
+                            <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                              <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M19 7l-.867 12.142A2 2 0 0116.138 21H7.862a2 2 0 01-1.995-1.858L5 7m5 4v6m4-6v6m1-10V4a1 1 0 00-1-1h-4a1 1 0 00-1 1v3M4 7h16" />
+                            </svg>
+                          </button>
+                        </div>
+                      </div>
+                    )}
+                  </div>
+                ))
+              )}
             </div>
           </div>
 


### PR DESCRIPTION
## Summary
- Issue #115「書きたいテーマ設定機能」を実装
- 器用貧乏から脱却するため10テーマ制限を設けました

## 実装内容

### バックエンド
- `writing_themes`テーブル作成とマイグレーション
- テーマCRUD操作のAPI実装
- 10テーマ制限バリデーション
- 認証・認可機能

### フロントエンド  
- SettingsPage.tsxにテーマ管理セクション追加
- テーマ追加・編集・削除UI
- テーマカウンター表示（n/10 テーマ）
- 制限到達時のUI制御

### UX改善
- 器用貧乏防止の説明文
- 適切なエラーメッセージ
- レスポンシブ対応

## Test plan
- [x] データベースマイグレーション実行
- [x] バックエンドAPI動作確認
- [x] 10テーマ制限動作確認
- [x] フロントエンドUI表示確認
- [x] Docker開発環境での動作確認

## 関連Issue
Closes #115

🤖 Generated with [Claude Code](https://claude.ai/code)