### PR TITLE
feat: テーマ別読書統計機能の完全実装

### DIFF
--- a/backend/src/database.ts
+++ b/backend/src/database.ts
@@ -486,6 +486,7 @@ export const getDailyThemeReadingTrends = async (userId: string, themeId?: numbe
           FROM reading_records r
           WHERE r.user_id = $1 
             AND DATE(r.created_at) >= CURRENT_DATE - INTERVAL '${days - 1} days'
+            AND r.theme_id IS NULL
           GROUP BY DATE(r.created_at)
         )
         SELECT 

--- a/backend/src/database.ts
+++ b/backend/src/database.ts
@@ -43,6 +43,7 @@ export interface ReadingRecord {
   contains_spoiler?: boolean;
   user_id?: string;
   user_email?: string;
+  theme_id?: number | null;
   created_at?: string;
   updated_at?: string;
   like_count?: number;
@@ -61,8 +62,8 @@ export interface Like {
 export const createReadingRecord = async (record: ReadingRecord) => {
   try {
     const query = `
-      INSERT INTO reading_records (title, link, reading_amount, learning, action, notes, is_not_book, custom_link, contains_spoiler, user_id, user_email)
-      VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11)
+      INSERT INTO reading_records (title, link, reading_amount, learning, action, notes, is_not_book, custom_link, contains_spoiler, user_id, user_email, theme_id)
+      VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12)
       RETURNING *
     `;
     const values = [
@@ -76,7 +77,8 @@ export const createReadingRecord = async (record: ReadingRecord) => {
       record.custom_link,
       record.contains_spoiler || false,
       record.user_id, 
-      record.user_email
+      record.user_email,
+      record.theme_id || null
     ];
     const result = await pool.query(query, values);
     return { success: true, data: result.rows[0] };
@@ -262,6 +264,17 @@ export interface WritingTheme {
   updated_at?: string;
 }
 
+// テーマ別統計の型定義
+export interface ThemeStats {
+  theme_id: number | null;
+  theme_name: string;
+  total_records: number;
+  daily_stats: Array<{
+    date: string;
+    count: number;
+  }>;
+}
+
 // ユーザー設定を取得
 export const getUserSettings = async (userId: string) => {
   try {
@@ -381,6 +394,147 @@ export const deleteWritingTheme = async (id: number, userId: string) => {
     return { success: true, data: result.rows[0] };
   } catch (error) {
     console.error('Delete writing theme error:', error);
+    return { success: false, error: error instanceof Error ? error.message : 'Unknown error' };
+  }
+};
+
+// テーマ別読書記録統計を取得
+export const getThemeBasedReadingStats = async (userId: string, themeId?: number) => {
+  try {
+    // テーマが指定されている場合は特定テーマの統計、されていない場合は全テーマの統計
+    const themeCondition = themeId ? 'AND r.theme_id = $2' : '';
+    const queryParams = themeId ? [userId, themeId] : [userId];
+    
+    const query = `
+      SELECT 
+        wt.id as theme_id,
+        COALESCE(wt.theme_name, '未分類') as theme_name,
+        COUNT(r.id) as total_records
+      FROM writing_themes wt
+      LEFT JOIN reading_records r ON wt.id = r.theme_id AND r.user_id = $1
+      WHERE wt.user_id = $1
+      ${themeCondition}
+      GROUP BY wt.id, wt.theme_name
+      
+      UNION ALL
+      
+      SELECT 
+        NULL as theme_id,
+        '未分類' as theme_name,
+        COUNT(r.id) as total_records
+      FROM reading_records r
+      WHERE r.user_id = $1 AND r.theme_id IS NULL
+      ${themeCondition}
+      
+      ORDER BY total_records DESC
+    `;
+    
+    const result = await pool.query(query, queryParams);
+    return { success: true, data: result.rows };
+  } catch (error) {
+    console.error('Get theme-based reading stats error:', error);
+    return { success: false, error: error instanceof Error ? error.message : 'Unknown error' };
+  }
+};
+
+// 日次テーマ別読書記録推移を取得
+export const getDailyThemeReadingTrends = async (userId: string, themeId?: number, days: number = 30) => {
+  try {
+    let query: string;
+    let queryParams: any[];
+    
+    if (themeId) {
+      query = `
+        WITH date_series AS (
+          SELECT generate_series(
+            CURRENT_DATE - INTERVAL '${days - 1} days',
+            CURRENT_DATE,
+            '1 day'::interval
+          )::date AS date
+        ),
+        daily_counts AS (
+          SELECT 
+            DATE(r.created_at) as date,
+            COUNT(*) as count
+          FROM reading_records r
+          WHERE r.user_id = $1 
+            AND DATE(r.created_at) >= CURRENT_DATE - INTERVAL '${days - 1} days'
+            AND r.theme_id = $2
+          GROUP BY DATE(r.created_at)
+        )
+        SELECT 
+          ds.date,
+          COALESCE(dc.count, 0) as count
+        FROM date_series ds
+        LEFT JOIN daily_counts dc ON ds.date = dc.date
+        ORDER BY ds.date
+      `;
+      queryParams = [userId, themeId];
+    } else {
+      query = `
+        WITH date_series AS (
+          SELECT generate_series(
+            CURRENT_DATE - INTERVAL '${days - 1} days',
+            CURRENT_DATE,
+            '1 day'::interval
+          )::date AS date
+        ),
+        daily_counts AS (
+          SELECT 
+            DATE(r.created_at) as date,
+            COUNT(*) as count
+          FROM reading_records r
+          WHERE r.user_id = $1 
+            AND DATE(r.created_at) >= CURRENT_DATE - INTERVAL '${days - 1} days'
+          GROUP BY DATE(r.created_at)
+        )
+        SELECT 
+          ds.date,
+          COALESCE(dc.count, 0) as count
+        FROM date_series ds
+        LEFT JOIN daily_counts dc ON ds.date = dc.date
+        ORDER BY ds.date
+      `;
+      queryParams = [userId];
+    }
+    
+    const result = await pool.query(query, queryParams);
+    return { success: true, data: result.rows };
+  } catch (error) {
+    console.error('Get daily theme reading trends error:', error);
+    return { success: false, error: error instanceof Error ? error.message : 'Unknown error' };
+  }
+};
+
+// 全テーマの累積統計を取得（プルダウン表示用）
+export const getAllThemeReadingStats = async (userId: string) => {
+  try {
+    const query = `
+      SELECT 
+        wt.id as theme_id,
+        wt.theme_name,
+        COUNT(r.id) as total_records
+      FROM writing_themes wt
+      LEFT JOIN reading_records r ON wt.id = r.theme_id AND r.user_id = $1
+      WHERE wt.user_id = $1
+      GROUP BY wt.id, wt.theme_name
+      
+      UNION ALL
+      
+      SELECT 
+        NULL as theme_id,
+        '未分類' as theme_name,
+        COUNT(r.id) as total_records
+      FROM reading_records r
+      WHERE r.user_id = $1 AND r.theme_id IS NULL
+      
+      ORDER BY total_records DESC
+    `;
+    
+    const result = await pool.query(query, [userId]);
+    return { success: true, data: result.rows };
+  } catch (error) {
+    console.error('Get all theme reading stats error:', error);
     return { success: false, error: error instanceof Error ? error.message : 'Unknown error' };
   }
 };

--- a/frontend/src/components/Dashboard.tsx
+++ b/frontend/src/components/Dashboard.tsx
@@ -28,10 +28,25 @@ function Dashboard() {
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
   const [dailyRecords, setDailyRecords] = useState<DailyRecord[]>([]);
+  
+  // テーマ関連のstate
+  const [allThemeStats, setAllThemeStats] = useState<any[]>([]);
+  const [selectedThemeId, setSelectedThemeId] = useState<number | null>(-1); // -1 = 全てのテーマ
+  const [themeStats, setThemeStats] = useState<any[]>([]);
+  const [dailyTrends, setDailyTrends] = useState<any[]>([]);
 
   useEffect(() => {
     fetchRecords();
+    fetchAllThemeStats();
   }, [isAuthenticated, token]);
+
+  // テーマが変更されたときに統計を更新
+  useEffect(() => {
+    if (selectedThemeId !== null) {
+      fetchThemeStats();
+      fetchDailyTrends();
+    }
+  }, [selectedThemeId]);
 
   const fetchRecords = async () => {
     // 認証チェック
@@ -67,6 +82,71 @@ function Dashboard() {
       setError('レコードの取得に失敗しました。');
     } finally {
       setLoading(false);
+    }
+  };
+
+  // 全テーマ統計を取得（プルダウン表示用）
+  const fetchAllThemeStats = async () => {
+    if (!isAuthenticated || !token) return;
+
+    try {
+      const API_BASE_URL = import.meta.env.VITE_API_BASE_URL || 'http://localhost:3001';
+      const response = await fetch(`${API_BASE_URL}/api/all-theme-reading-stats`, {
+        headers: {
+          'Authorization': `Bearer ${token}`,
+        },
+      });
+      
+      if (response.ok) {
+        const result = await response.json();
+        setAllThemeStats(result.data || []);
+      }
+    } catch (error) {
+      console.error('テーマ統計取得エラー:', error);
+    }
+  };
+
+  // 選択されたテーマの統計を取得
+  const fetchThemeStats = async () => {
+    if (!isAuthenticated || !token) return;
+
+    try {
+      const API_BASE_URL = import.meta.env.VITE_API_BASE_URL || 'http://localhost:3001';
+      const themeParam = selectedThemeId && selectedThemeId !== -1 ? `?themeId=${selectedThemeId}` : '';
+      const response = await fetch(`${API_BASE_URL}/api/theme-reading-stats${themeParam}`, {
+        headers: {
+          'Authorization': `Bearer ${token}`,
+        },
+      });
+      
+      if (response.ok) {
+        const result = await response.json();
+        setThemeStats(result.data || []);
+      }
+    } catch (error) {
+      console.error('テーマ別統計取得エラー:', error);
+    }
+  };
+
+  // 日次推移データを取得
+  const fetchDailyTrends = async () => {
+    if (!isAuthenticated || !token) return;
+
+    try {
+      const API_BASE_URL = import.meta.env.VITE_API_BASE_URL || 'http://localhost:3001';
+      const themeParam = selectedThemeId && selectedThemeId !== -1 ? `?themeId=${selectedThemeId}` : '';
+      const response = await fetch(`${API_BASE_URL}/api/daily-theme-reading-trends${themeParam}`, {
+        headers: {
+          'Authorization': `Bearer ${token}`,
+        },
+      });
+      
+      if (response.ok) {
+        const result = await response.json();
+        setDailyTrends(result.data || []);
+      }
+    } catch (error) {
+      console.error('日次推移取得エラー:', error);
     }
   };
 
@@ -154,6 +234,85 @@ function Dashboard() {
           ダッシュボード
         </h1>
       </div>
+
+      {/* テーマ別統計セクション */}
+      {isAuthenticated && (
+        <div className="mb-8 p-6 bg-gradient-to-r from-orange-50 to-yellow-50 rounded-xl border border-orange-200">
+          <h2 className="text-xl font-semibold text-orange-800 mb-4 flex items-center">
+            📊 テーマ別読書統計
+          </h2>
+          
+          {/* テーマ選択プルダウン */}
+          <div className="mb-6">
+            <label className="block text-sm font-medium text-gray-700 mb-2">
+              表示するテーマを選択
+            </label>
+            <select
+              value={selectedThemeId || -1}
+              onChange={(e) => setSelectedThemeId(parseInt(e.target.value))}
+              className="w-full sm:w-auto px-3 py-2 border border-gray-300 rounded-md focus:ring-2 focus:ring-orange-500 focus:border-orange-500"
+            >
+              {allThemeStats.map((theme) => (
+                <option key={theme.theme_id || 'null'} value={theme.theme_id || -1}>
+                  {theme.theme_name} ({theme.total_records}記録)
+                </option>
+              ))}
+            </select>
+          </div>
+
+          {/* 累積読書記録数 */}
+          <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-4 mb-6">
+            <div className="bg-white rounded-lg p-4 shadow-sm border border-orange-100">
+              <div className="text-2xl font-bold text-orange-600">
+                {allThemeStats.find(t => (t.theme_id || -1) === selectedThemeId)?.total_records || 0}
+              </div>
+              <div className="text-sm text-gray-600 mt-1">累積読書記録数</div>
+            </div>
+            
+            <div className="bg-white rounded-lg p-4 shadow-sm border border-orange-100">
+              <div className="text-2xl font-bold text-blue-600">
+                {dailyTrends.reduce((sum, day) => sum + parseInt(day.count), 0)}
+              </div>
+              <div className="text-sm text-gray-600 mt-1">過去30日間</div>
+            </div>
+            
+            <div className="bg-white rounded-lg p-4 shadow-sm border border-orange-100">
+              <div className="text-2xl font-bold text-green-600">
+                {dailyTrends.length > 0 ? Math.round(dailyTrends.reduce((sum, day) => sum + parseInt(day.count), 0) / 30 * 10) / 10 : 0}
+              </div>
+              <div className="text-sm text-gray-600 mt-1">日平均記録数</div>
+            </div>
+          </div>
+
+          {/* 日次推移グラフ（シンプルなバー表示） */}
+          <div className="bg-white rounded-lg p-4 shadow-sm border border-orange-100">
+            <h3 className="text-lg font-medium text-gray-800 mb-3">📈 過去30日間の推移</h3>
+            <div className="flex items-end space-x-1 h-32 overflow-x-auto">
+              {dailyTrends.slice(-30).map((day, index) => (
+                <div
+                  key={day.date}
+                  className="flex flex-col items-center min-w-[20px]"
+                  title={`${day.date}: ${day.count}記録`}
+                >
+                  <div
+                    className="bg-gradient-to-t from-orange-500 to-orange-300 rounded-t min-w-[18px] transition-all hover:from-orange-600 hover:to-orange-400"
+                    style={{
+                      height: `${Math.max(day.count * 20, 4)}px`,
+                    }}
+                  ></div>
+                  <div className="text-xs text-gray-500 mt-1 transform rotate-45 origin-left whitespace-nowrap">
+                    {new Date(day.date).getDate()}
+                  </div>
+                </div>
+              ))}
+            </div>
+            <div className="flex justify-between text-xs text-gray-500 mt-2">
+              <span>30日前</span>
+              <span>今日</span>
+            </div>
+          </div>
+        </div>
+      )}
 
       {/* 累積読書記録数 */}
       <div className="bg-gradient-to-r from-orange-50 to-yellow-50 rounded-xl p-6 mb-8 border border-orange-200">

--- a/frontend/src/components/Dashboard.tsx
+++ b/frontend/src/components/Dashboard.tsx
@@ -326,7 +326,7 @@ function Dashboard() {
               className="w-full sm:w-auto px-3 py-2 border border-gray-300 rounded-md focus:ring-2 focus:ring-orange-500 focus:border-orange-500"
             >
               <option value="">未分類</option>
-              {allThemeStats.filter(theme => theme.theme_id !== null).map((theme) => (
+              {allThemeStats.filter(theme => theme.theme_id !== null && theme.theme_id !== -1).map((theme) => (
                 <option key={theme.theme_id} value={theme.theme_id}>
                   {theme.theme_name} ({theme.total_records}記録)
                 </option>

--- a/frontend/src/components/Dashboard.tsx
+++ b/frontend/src/components/Dashboard.tsx
@@ -135,15 +135,24 @@ function Dashboard() {
     try {
       const API_BASE_URL = import.meta.env.VITE_API_BASE_URL || 'http://localhost:3001';
       const themeParam = selectedThemeId !== null ? `&themeId=${selectedThemeId}` : '';
-      const response = await fetch(`${API_BASE_URL}/api/daily-theme-reading-trends?days=14${themeParam}`, {
+      const url = `${API_BASE_URL}/api/daily-theme-reading-trends?days=14${themeParam}`;
+      console.log('fetchDailyTrends URL:', url);
+      console.log('selectedThemeId:', selectedThemeId);
+      
+      const response = await fetch(url, {
         headers: {
           'Authorization': `Bearer ${token}`,
         },
       });
       
+      console.log('fetchDailyTrends response status:', response.status);
+      
       if (response.ok) {
         const result = await response.json();
+        console.log('fetchDailyTrends result:', result);
         setDailyTrends(result.data || []);
+      } else {
+        console.error('fetchDailyTrends HTTP error:', response.status, response.statusText);
       }
     } catch (error) {
       console.error('日次推移取得エラー:', error);
@@ -354,53 +363,59 @@ function Dashboard() {
           {/* 日次推移グラフ（折れ線グラフ） */}
           <div className="bg-white rounded-lg p-4 shadow-sm border border-orange-100">
             <h3 className="text-lg font-medium text-gray-800 mb-3">📈 過去14日間の推移</h3>
-            <div className="h-64 relative">
-              <ResponsiveContainer width="100%" height="100%">
-                <LineChart data={dailyTrends.slice(-14).map(day => ({
-                  date: formatDateForChart(day.date),
-                  count: parseInt(day.count)
-                }))}>
-                  <CartesianGrid strokeDasharray="3 3" stroke="#e5e7eb" />
-                  <XAxis 
-                    dataKey="date" 
-                    stroke="#6b7280"
-                    fontSize={12}
-                    tickLine={false}
-                    axisLine={false}
-                  />
-                  <YAxis 
-                    stroke="#6b7280"
-                    fontSize={12}
-                    tickLine={false}
-                    axisLine={false}
-                    allowDecimals={false}
-                  />
-                  <Tooltip 
-                    contentStyle={{
-                      backgroundColor: 'white',
-                      border: '1px solid #e5e7eb',
-                      borderRadius: '8px',
-                      boxShadow: '0 4px 6px -1px rgba(0, 0, 0, 0.1)'
-                    }}
-                    labelStyle={{ color: '#374151' }}
-                    formatter={(value) => [value, '読書記録数']}
-                    labelFormatter={(label) => `${label}日前`}
-                  />
-                  <Line 
-                    type="monotone" 
-                    dataKey="count" 
-                    stroke="#3b82f6" 
-                    strokeWidth={3}
-                    dot={{ fill: '#3b82f6', strokeWidth: 2, r: 4 }}
-                    activeDot={{ r: 6, stroke: '#3b82f6', strokeWidth: 2 }}
-                  />
-                </LineChart>
-              </ResponsiveContainer>
-              {/* 「日前」ラベルを右端に追加 */}
-              <div className="absolute bottom-6 right-8 text-xs text-gray-500">
-                日前
+            {dailyTrends.length > 0 ? (
+              <div className="h-64 relative">
+                <ResponsiveContainer width="100%" height="100%">
+                  <LineChart data={dailyTrends.slice(-14).map(day => ({
+                    date: formatDateForChart(day.date),
+                    count: parseInt(day.count)
+                  }))}>
+                    <CartesianGrid strokeDasharray="3 3" stroke="#e5e7eb" />
+                    <XAxis 
+                      dataKey="date" 
+                      stroke="#6b7280"
+                      fontSize={12}
+                      tickLine={false}
+                      axisLine={false}
+                    />
+                    <YAxis 
+                      stroke="#6b7280"
+                      fontSize={12}
+                      tickLine={false}
+                      axisLine={false}
+                      allowDecimals={false}
+                    />
+                    <Tooltip 
+                      contentStyle={{
+                        backgroundColor: 'white',
+                        border: '1px solid #e5e7eb',
+                        borderRadius: '8px',
+                        boxShadow: '0 4px 6px -1px rgba(0, 0, 0, 0.1)'
+                      }}
+                      labelStyle={{ color: '#374151' }}
+                      formatter={(value) => [value, '読書記録数']}
+                      labelFormatter={(label) => `${label}日前`}
+                    />
+                    <Line 
+                      type="monotone" 
+                      dataKey="count" 
+                      stroke="#3b82f6" 
+                      strokeWidth={3}
+                      dot={{ fill: '#3b82f6', strokeWidth: 2, r: 4 }}
+                      activeDot={{ r: 6, stroke: '#3b82f6', strokeWidth: 2 }}
+                    />
+                  </LineChart>
+                </ResponsiveContainer>
+                {/* 「日前」ラベルを右端に追加 */}
+                <div className="absolute bottom-6 right-8 text-xs text-gray-500">
+                  日前
+                </div>
               </div>
-            </div>
+            ) : (
+              <div className="h-64 flex items-center justify-center">
+                <p className="text-gray-500">データを読み込み中...</p>
+              </div>
+            )}
             <p className="text-sm text-blue-600 mt-2 text-center">
               過去14日間（13日前〜今日）の読書記録数を表示しています
             </p>

--- a/frontend/src/components/Dashboard.tsx
+++ b/frontend/src/components/Dashboard.tsx
@@ -361,32 +361,59 @@ function Dashboard() {
             </div>
           </div>
 
-          {/* 日次推移グラフ（シンプルなバー表示） */}
+          {/* 日次推移グラフ（折れ線グラフ） */}
           <div className="bg-white rounded-lg p-4 shadow-sm border border-orange-100">
             <h3 className="text-lg font-medium text-gray-800 mb-3">📈 過去14日間の推移</h3>
-            <div className="flex items-end space-x-1 h-32 overflow-x-auto">
-              {dailyTrends.slice(-14).map((day, index) => (
-                <div
-                  key={day.date}
-                  className="flex flex-col items-center min-w-[20px]"
-                  title={`${day.date}: ${day.count}記録`}
-                >
-                  <div
-                    className="bg-gradient-to-t from-orange-500 to-orange-300 rounded-t min-w-[18px] transition-all hover:from-orange-600 hover:to-orange-400"
-                    style={{
-                      height: `${Math.max(day.count * 20, 4)}px`,
+            <div className="h-64 relative">
+              <ResponsiveContainer width="100%" height="100%">
+                <LineChart data={dailyTrends.slice(-14).map(day => ({
+                  date: formatDateForChart(day.date),
+                  count: parseInt(day.count)
+                }))}>
+                  <CartesianGrid strokeDasharray="3 3" stroke="#e5e7eb" />
+                  <XAxis 
+                    dataKey="date" 
+                    stroke="#6b7280"
+                    fontSize={12}
+                    tickLine={false}
+                    axisLine={false}
+                  />
+                  <YAxis 
+                    stroke="#6b7280"
+                    fontSize={12}
+                    tickLine={false}
+                    axisLine={false}
+                    allowDecimals={false}
+                  />
+                  <Tooltip 
+                    contentStyle={{
+                      backgroundColor: 'white',
+                      border: '1px solid #e5e7eb',
+                      borderRadius: '8px',
+                      boxShadow: '0 4px 6px -1px rgba(0, 0, 0, 0.1)'
                     }}
-                  ></div>
-                  <div className="text-xs text-gray-500 mt-1 transform rotate-45 origin-left whitespace-nowrap">
-                    {new Date(day.date).getDate()}
-                  </div>
-                </div>
-              ))}
+                    labelStyle={{ color: '#374151' }}
+                    formatter={(value) => [value, '読書記録数']}
+                    labelFormatter={(label) => `${label}日前`}
+                  />
+                  <Line 
+                    type="monotone" 
+                    dataKey="count" 
+                    stroke="#f97316" 
+                    strokeWidth={3}
+                    dot={{ fill: '#f97316', strokeWidth: 2, r: 4 }}
+                    activeDot={{ r: 6, stroke: '#f97316', strokeWidth: 2 }}
+                  />
+                </LineChart>
+              </ResponsiveContainer>
+              {/* 「日前」ラベルを右端に追加 */}
+              <div className="absolute bottom-6 right-8 text-xs text-gray-500">
+                日前
+              </div>
             </div>
-            <div className="flex justify-between text-xs text-gray-500 mt-2">
-              <span>13日前</span>
-              <span>今日</span>
-            </div>
+            <p className="text-sm text-orange-600 mt-2 text-center">
+              過去14日間（13日前〜今日）の読書記録数を表示しています
+            </p>
           </div>
         </div>
       )}

--- a/frontend/src/components/Dashboard.tsx
+++ b/frontend/src/components/Dashboard.tsx
@@ -134,8 +134,8 @@ function Dashboard() {
 
     try {
       const API_BASE_URL = import.meta.env.VITE_API_BASE_URL || 'http://localhost:3001';
-      const themeParam = selectedThemeId !== null ? `?themeId=${selectedThemeId}` : '';
-      const response = await fetch(`${API_BASE_URL}/api/daily-theme-reading-trends${themeParam}`, {
+      const themeParam = selectedThemeId !== null ? `&themeId=${selectedThemeId}` : '';
+      const response = await fetch(`${API_BASE_URL}/api/daily-theme-reading-trends?days=14${themeParam}`, {
         headers: {
           'Authorization': `Bearer ${token}`,
         },
@@ -350,12 +350,12 @@ function Dashboard() {
               <div className="text-2xl font-bold text-blue-600">
                 {dailyTrends.reduce((sum, day) => sum + parseInt(day.count), 0)}
               </div>
-              <div className="text-sm text-gray-600 mt-1">過去30日間</div>
+              <div className="text-sm text-gray-600 mt-1">過去14日間</div>
             </div>
             
             <div className="bg-white rounded-lg p-4 shadow-sm border border-orange-100">
               <div className="text-2xl font-bold text-green-600">
-                {dailyTrends.length > 0 ? Math.round(dailyTrends.reduce((sum, day) => sum + parseInt(day.count), 0) / 30 * 10) / 10 : 0}
+                {dailyTrends.length > 0 ? Math.round(dailyTrends.reduce((sum, day) => sum + parseInt(day.count), 0) / 14 * 10) / 10 : 0}
               </div>
               <div className="text-sm text-gray-600 mt-1">日平均記録数</div>
             </div>
@@ -363,9 +363,9 @@ function Dashboard() {
 
           {/* 日次推移グラフ（シンプルなバー表示） */}
           <div className="bg-white rounded-lg p-4 shadow-sm border border-orange-100">
-            <h3 className="text-lg font-medium text-gray-800 mb-3">📈 過去30日間の推移</h3>
+            <h3 className="text-lg font-medium text-gray-800 mb-3">📈 過去14日間の推移</h3>
             <div className="flex items-end space-x-1 h-32 overflow-x-auto">
-              {dailyTrends.slice(-30).map((day, index) => (
+              {dailyTrends.slice(-14).map((day, index) => (
                 <div
                   key={day.date}
                   className="flex flex-col items-center min-w-[20px]"
@@ -384,7 +384,7 @@ function Dashboard() {
               ))}
             </div>
             <div className="flex justify-between text-xs text-gray-500 mt-2">
-              <span>30日前</span>
+              <span>13日前</span>
               <span>今日</span>
             </div>
           </div>

--- a/frontend/src/components/Dashboard.tsx
+++ b/frontend/src/components/Dashboard.tsx
@@ -28,6 +28,7 @@ function Dashboard() {
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
   const [dailyRecords, setDailyRecords] = useState<DailyRecord[]>([]);
+  const [authInitialized, setAuthInitialized] = useState(false);
   
   // テーマ関連のstate
   const [allThemeStats, setAllThemeStats] = useState<any[]>([]);
@@ -35,11 +36,18 @@ function Dashboard() {
   const [themeStats, setThemeStats] = useState<any[]>([]);
   const [dailyTrends, setDailyTrends] = useState<any[]>([]);
 
+  // 認証状態の初期化を監視
   useEffect(() => {
-    fetchRecords();
-    fetchAllThemeStats();
-    fetchDailyTrends(); // 初期表示時にも日次推移を取得
-  }, [isAuthenticated, token]);
+    setAuthInitialized(true);
+  }, []);
+
+  useEffect(() => {
+    if (authInitialized && isAuthenticated && token) {
+      fetchRecords();
+      fetchAllThemeStats();
+      fetchDailyTrends(); // 初期表示時にも日次推移を取得
+    }
+  }, [authInitialized, isAuthenticated, token]);
 
   // テーマが変更されたときに統計を更新
   useEffect(() => {
@@ -202,7 +210,7 @@ function Dashboard() {
     return `${diffDays}`;
   };
 
-  if (loading) {
+  if (!authInitialized || loading) {
     return (
       <div className="bg-white/80 backdrop-blur-sm rounded-2xl shadow-xl p-8 border border-orange-100 mt-8 sm:mt-0">
         <div className="flex items-center justify-center mb-8">
@@ -229,6 +237,22 @@ function Dashboard() {
         </div>
         <div className="text-center py-12">
           <p className="text-red-600">{error}</p>
+        </div>
+      </div>
+    );
+  }
+
+  if (authInitialized && !isAuthenticated) {
+    return (
+      <div className="bg-white/80 backdrop-blur-sm rounded-2xl shadow-xl p-8 border border-orange-100 mt-8 sm:mt-0">
+        <div className="flex items-center justify-center mb-8">
+          <BookIcon size={48} />
+          <h1 className="text-2xl sm:text-3xl md:text-4xl font-bold text-center text-orange-800 ml-3 leading-tight">
+            ダッシュボード
+          </h1>
+        </div>
+        <div className="text-center py-12">
+          <p className="text-orange-600">ログインが必要です。</p>
         </div>
       </div>
     );

--- a/frontend/src/components/Dashboard.tsx
+++ b/frontend/src/components/Dashboard.tsx
@@ -38,14 +38,13 @@ function Dashboard() {
   useEffect(() => {
     fetchRecords();
     fetchAllThemeStats();
+    fetchDailyTrends(); // 初期表示時にも日次推移を取得
   }, [isAuthenticated, token]);
 
   // テーマが変更されたときに統計を更新
   useEffect(() => {
-    if (selectedThemeId !== null) {
-      fetchThemeStats();
-      fetchDailyTrends();
-    }
+    fetchThemeStats();
+    fetchDailyTrends();
   }, [selectedThemeId]);
 
   const fetchRecords = async () => {

--- a/frontend/src/components/Dashboard.tsx
+++ b/frontend/src/components/Dashboard.tsx
@@ -235,9 +235,82 @@ function Dashboard() {
         </h1>
       </div>
 
+
+
+      {/* 累積読書記録数 */}
+      <div className="bg-gradient-to-r from-orange-50 to-yellow-50 rounded-xl p-6 mb-8 border border-orange-200">
+        <h2 className="text-xl font-semibold text-orange-800 mb-4 flex items-center">
+          <span className="mr-2">📊</span>
+          累積読書記録数
+        </h2>
+        <div className="text-center">
+          <div className="text-4xl font-bold text-orange-600 mb-2">
+            {records.length}
+          </div>
+          <p className="text-orange-700">件の読書記録</p>
+        </div>
+      </div>
+
+      {/* 日次推移グラフ（全ユーザーに表示） */}
+      {dailyRecords.length > 0 && (
+        <div className="bg-gradient-to-r from-blue-50 to-indigo-50 rounded-xl p-6 border border-blue-200">
+          <h2 className="text-xl font-semibold text-blue-800 mb-4 flex items-center">
+            <span className="mr-2">📈</span>
+            読書記録数の日次推移
+          </h2>
+          <div className="h-64 relative">
+            <ResponsiveContainer width="100%" height="100%">
+              <LineChart data={dailyRecords}>
+                <CartesianGrid strokeDasharray="3 3" stroke="#e5e7eb" />
+                <XAxis 
+                  dataKey="date" 
+                  stroke="#6b7280"
+                  fontSize={12}
+                  tickLine={false}
+                  axisLine={false}
+                />
+                <YAxis 
+                  stroke="#6b7280"
+                  fontSize={12}
+                  tickLine={false}
+                  axisLine={false}
+                  allowDecimals={false}
+                />
+                <Tooltip 
+                  contentStyle={{
+                    backgroundColor: 'white',
+                    border: '1px solid #e5e7eb',
+                    borderRadius: '8px',
+                    boxShadow: '0 4px 6px -1px rgba(0, 0, 0, 0.1)'
+                  }}
+                  labelStyle={{ color: '#374151' }}
+                  formatter={(value) => [value, '読書記録数']}
+                  labelFormatter={(label) => `${label}日前`}
+                />
+                <Line 
+                  type="monotone" 
+                  dataKey="count" 
+                  stroke="#3b82f6" 
+                  strokeWidth={3}
+                  dot={{ fill: '#3b82f6', strokeWidth: 2, r: 4 }}
+                  activeDot={{ r: 6, stroke: '#3b82f6', strokeWidth: 2 }}
+                />
+              </LineChart>
+            </ResponsiveContainer>
+            {/* 「日前」ラベルを右端に追加 */}
+            <div className="absolute bottom-6 right-8 text-xs text-gray-500">
+              日前
+            </div>
+          </div>
+          <p className="text-sm text-blue-600 mt-2 text-center">
+            過去14日間（13日前〜今日）の読書記録数を表示しています
+          </p>
+        </div>
+      )}
+
       {/* テーマ別統計セクション */}
       {isAuthenticated && (
-        <div className="mb-8 p-6 bg-gradient-to-r from-orange-50 to-yellow-50 rounded-xl border border-orange-200">
+        <div className="mt-8 p-6 bg-gradient-to-r from-orange-50 to-yellow-50 rounded-xl border border-orange-200">
           <h2 className="text-xl font-semibold text-orange-800 mb-4 flex items-center">
             📊 テーマ別読書統計
           </h2>
@@ -311,77 +384,6 @@ function Dashboard() {
               <span>今日</span>
             </div>
           </div>
-        </div>
-      )}
-
-      {/* 累積読書記録数 */}
-      <div className="bg-gradient-to-r from-orange-50 to-yellow-50 rounded-xl p-6 mb-8 border border-orange-200">
-        <h2 className="text-xl font-semibold text-orange-800 mb-4 flex items-center">
-          <span className="mr-2">📊</span>
-          累積読書記録数
-        </h2>
-        <div className="text-center">
-          <div className="text-4xl font-bold text-orange-600 mb-2">
-            {records.length}
-          </div>
-          <p className="text-orange-700">件の読書記録</p>
-        </div>
-      </div>
-
-      {/* 日次推移グラフ（全ユーザーに表示） */}
-      {dailyRecords.length > 0 && (
-        <div className="bg-gradient-to-r from-blue-50 to-indigo-50 rounded-xl p-6 border border-blue-200">
-          <h2 className="text-xl font-semibold text-blue-800 mb-4 flex items-center">
-            <span className="mr-2">📈</span>
-            読書記録数の日次推移
-          </h2>
-          <div className="h-64 relative">
-            <ResponsiveContainer width="100%" height="100%">
-              <LineChart data={dailyRecords}>
-                <CartesianGrid strokeDasharray="3 3" stroke="#e5e7eb" />
-                <XAxis 
-                  dataKey="date" 
-                  stroke="#6b7280"
-                  fontSize={12}
-                  tickLine={false}
-                  axisLine={false}
-                />
-                <YAxis 
-                  stroke="#6b7280"
-                  fontSize={12}
-                  tickLine={false}
-                  axisLine={false}
-                  allowDecimals={false}
-                />
-                <Tooltip 
-                  contentStyle={{
-                    backgroundColor: 'white',
-                    border: '1px solid #e5e7eb',
-                    borderRadius: '8px',
-                    boxShadow: '0 4px 6px -1px rgba(0, 0, 0, 0.1)'
-                  }}
-                  labelStyle={{ color: '#374151' }}
-                  formatter={(value) => [value, '読書記録数']}
-                  labelFormatter={(label) => `${label}日前`}
-                />
-                <Line 
-                  type="monotone" 
-                  dataKey="count" 
-                  stroke="#3b82f6" 
-                  strokeWidth={3}
-                  dot={{ fill: '#3b82f6', strokeWidth: 2, r: 4 }}
-                  activeDot={{ r: 6, stroke: '#3b82f6', strokeWidth: 2 }}
-                />
-              </LineChart>
-            </ResponsiveContainer>
-            {/* 「日前」ラベルを右端に追加 */}
-            <div className="absolute bottom-6 right-8 text-xs text-gray-500">
-              日前
-            </div>
-          </div>
-          <p className="text-sm text-blue-600 mt-2 text-center">
-            過去14日間（13日前〜今日）の読書記録数を表示しています
-          </p>
         </div>
       )}
 

--- a/frontend/src/components/Dashboard.tsx
+++ b/frontend/src/components/Dashboard.tsx
@@ -31,7 +31,7 @@ function Dashboard() {
   
   // テーマ関連のstate
   const [allThemeStats, setAllThemeStats] = useState<any[]>([]);
-  const [selectedThemeId, setSelectedThemeId] = useState<number | null>(-1); // -1 = 全てのテーマ
+  const [selectedThemeId, setSelectedThemeId] = useState<number | null>(null); // null = 未分類
   const [themeStats, setThemeStats] = useState<any[]>([]);
   const [dailyTrends, setDailyTrends] = useState<any[]>([]);
 
@@ -112,7 +112,7 @@ function Dashboard() {
 
     try {
       const API_BASE_URL = import.meta.env.VITE_API_BASE_URL || 'http://localhost:3001';
-      const themeParam = selectedThemeId && selectedThemeId !== -1 ? `?themeId=${selectedThemeId}` : '';
+      const themeParam = selectedThemeId !== null ? `?themeId=${selectedThemeId}` : '';
       const response = await fetch(`${API_BASE_URL}/api/theme-reading-stats${themeParam}`, {
         headers: {
           'Authorization': `Bearer ${token}`,
@@ -134,7 +134,7 @@ function Dashboard() {
 
     try {
       const API_BASE_URL = import.meta.env.VITE_API_BASE_URL || 'http://localhost:3001';
-      const themeParam = selectedThemeId && selectedThemeId !== -1 ? `?themeId=${selectedThemeId}` : '';
+      const themeParam = selectedThemeId !== null ? `?themeId=${selectedThemeId}` : '';
       const response = await fetch(`${API_BASE_URL}/api/daily-theme-reading-trends${themeParam}`, {
         headers: {
           'Authorization': `Bearer ${token}`,
@@ -321,12 +321,13 @@ function Dashboard() {
               表示するテーマを選択
             </label>
             <select
-              value={selectedThemeId || -1}
-              onChange={(e) => setSelectedThemeId(parseInt(e.target.value))}
+              value={selectedThemeId || ''}
+              onChange={(e) => setSelectedThemeId(e.target.value ? parseInt(e.target.value) : null)}
               className="w-full sm:w-auto px-3 py-2 border border-gray-300 rounded-md focus:ring-2 focus:ring-orange-500 focus:border-orange-500"
             >
-              {allThemeStats.map((theme) => (
-                <option key={theme.theme_id || 'null'} value={theme.theme_id || -1}>
+              <option value="">未分類</option>
+              {allThemeStats.filter(theme => theme.theme_id !== null).map((theme) => (
+                <option key={theme.theme_id} value={theme.theme_id}>
                   {theme.theme_name} ({theme.total_records}記録)
                 </option>
               ))}
@@ -337,7 +338,10 @@ function Dashboard() {
           <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-4 mb-6">
             <div className="bg-white rounded-lg p-4 shadow-sm border border-orange-100">
               <div className="text-2xl font-bold text-orange-600">
-                {allThemeStats.find(t => (t.theme_id || -1) === selectedThemeId)?.total_records || 0}
+                {selectedThemeId === null 
+                  ? allThemeStats.find(t => t.theme_id === null)?.total_records || 0
+                  : allThemeStats.find(t => t.theme_id === selectedThemeId)?.total_records || 0
+                }
               </div>
               <div className="text-sm text-gray-600 mt-1">累積読書記録数</div>
             </div>

--- a/frontend/src/components/Dashboard.tsx
+++ b/frontend/src/components/Dashboard.tsx
@@ -335,29 +335,19 @@ function Dashboard() {
           </div>
 
           {/* 累積読書記録数 */}
-          <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-4 mb-6">
-            <div className="bg-white rounded-lg p-4 shadow-sm border border-orange-100">
-              <div className="text-2xl font-bold text-orange-600">
+          <div className="bg-gradient-to-r from-orange-50 to-yellow-50 rounded-xl p-6 mb-6 border border-orange-200">
+            <h3 className="text-lg font-semibold text-orange-800 mb-4 flex items-center">
+              <span className="mr-2">📊</span>
+              累積読書記録数
+            </h3>
+            <div className="text-center">
+              <div className="text-4xl font-bold text-orange-600 mb-2">
                 {selectedThemeId === null 
                   ? allThemeStats.find(t => t.theme_id === null)?.total_records || 0
                   : allThemeStats.find(t => t.theme_id === selectedThemeId)?.total_records || 0
                 }
               </div>
-              <div className="text-sm text-gray-600 mt-1">累積読書記録数</div>
-            </div>
-            
-            <div className="bg-white rounded-lg p-4 shadow-sm border border-orange-100">
-              <div className="text-2xl font-bold text-blue-600">
-                {dailyTrends.reduce((sum, day) => sum + parseInt(day.count), 0)}
-              </div>
-              <div className="text-sm text-gray-600 mt-1">過去14日間</div>
-            </div>
-            
-            <div className="bg-white rounded-lg p-4 shadow-sm border border-orange-100">
-              <div className="text-2xl font-bold text-green-600">
-                {dailyTrends.length > 0 ? Math.round(dailyTrends.reduce((sum, day) => sum + parseInt(day.count), 0) / 14 * 10) / 10 : 0}
-              </div>
-              <div className="text-sm text-gray-600 mt-1">日平均記録数</div>
+              <p className="text-orange-700">件の読書記録</p>
             </div>
           </div>
 

--- a/frontend/src/components/Dashboard.tsx
+++ b/frontend/src/components/Dashboard.tsx
@@ -399,10 +399,10 @@ function Dashboard() {
                   <Line 
                     type="monotone" 
                     dataKey="count" 
-                    stroke="#f97316" 
+                    stroke="#3b82f6" 
                     strokeWidth={3}
-                    dot={{ fill: '#f97316', strokeWidth: 2, r: 4 }}
-                    activeDot={{ r: 6, stroke: '#f97316', strokeWidth: 2 }}
+                    dot={{ fill: '#3b82f6', strokeWidth: 2, r: 4 }}
+                    activeDot={{ r: 6, stroke: '#3b82f6', strokeWidth: 2 }}
                   />
                 </LineChart>
               </ResponsiveContainer>
@@ -411,7 +411,7 @@ function Dashboard() {
                 日前
               </div>
             </div>
-            <p className="text-sm text-orange-600 mt-2 text-center">
+            <p className="text-sm text-blue-600 mt-2 text-center">
               過去14日間（13日前〜今日）の読書記録数を表示しています
             </p>
           </div>

--- a/frontend/src/components/InputForm.tsx
+++ b/frontend/src/components/InputForm.tsx
@@ -13,6 +13,7 @@ interface FormData {
   isNotBook: boolean;
   customLink: string;
   containsSpoiler: boolean;
+  themeId: number | null;
 }
 
 function InputForm() {
@@ -26,13 +27,20 @@ function InputForm() {
     notes: '',
     isNotBook: false,
     customLink: '',
-    containsSpoiler: false
+    containsSpoiler: false,
+    themeId: null
   });
   const [isSubmitting, setIsSubmitting] = useState(false);
   const [isSearchingAmazon, setIsSearchingAmazon] = useState(false);
   const [amazonLinkFound, setAmazonLinkFound] = useState(false);
   const [isAccordionOpen, setIsAccordionOpen] = useState(false);
   const [, setTitleExtractionSuccess] = useState(false);
+  
+  // テーマ選択用のstate
+  const [userThemes, setUserThemes] = useState<Array<{
+    id: number;
+    theme_name: string;
+  }>>([]);
   
   // Amazon検索とオートコンプリート用の状態
   const [amazonSearchResults, setAmazonSearchResults] = useState<Array<{
@@ -69,6 +77,13 @@ function InputForm() {
       setTitleExtractionSuccess(formData.title === '' ? false : isValidBookTitle(formData.title));
     }
   }, [formData.isNotBook, formData.title]);
+
+  // ユーザーのテーマ一覧を取得
+  useEffect(() => {
+    if (isAuthenticated && token) {
+      fetchUserThemes();
+    }
+  }, [isAuthenticated, token]);
 
   // クリーンアップ処理
   useEffect(() => {
@@ -409,6 +424,25 @@ function InputForm() {
   };
 
 
+  // ユーザーのテーマ一覧を取得
+  const fetchUserThemes = async () => {
+    try {
+      const API_BASE_URL = import.meta.env.VITE_API_BASE_URL || 'http://localhost:3001';
+      const response = await fetch(`${API_BASE_URL}/api/writing-themes`, {
+        headers: {
+          'Authorization': `Bearer ${token}`,
+        },
+      });
+      
+      if (response.ok) {
+        const result = await response.json();
+        setUserThemes(result.data || []);
+      }
+    } catch (error) {
+      console.error('テーマ取得エラー:', error);
+    }
+  };
+
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault();
     
@@ -456,7 +490,8 @@ function InputForm() {
           notes: formData.notes,
           isNotBook: formData.isNotBook,
           customLink: formData.customLink,
-          containsSpoiler: formData.containsSpoiler
+          containsSpoiler: formData.containsSpoiler,
+          themeId: formData.themeId
         }),
       });
 
@@ -742,6 +777,38 @@ function InputForm() {
             <option value="1章">1章</option>
             <option value="1冊・全文">1冊・全文</option>
           </select>
+        </div>
+
+        {/* 2.5. テーマ選択 */}
+        <div>
+          <label htmlFor="themeId" className="block text-sm font-medium text-gray-700 mb-2">
+            2.5. 書きたいテーマ（任意）
+            <span className="text-xs text-gray-500 ml-2">
+              設定したテーマから選択できます。設定は<a href="/settings" className="text-orange-600 hover:text-orange-700 underline">設定ページ</a>から行えます。
+            </span>
+          </label>
+          <select
+            id="themeId"
+            name="themeId"
+            value={formData.themeId || ''}
+            onChange={(e) => setFormData(prev => ({ 
+              ...prev, 
+              themeId: e.target.value ? parseInt(e.target.value) : null 
+            }))}
+            className="w-full px-4 py-3 border border-gray-300 rounded-lg focus:ring-2 focus:ring-orange-500 focus:border-transparent transition-colors"
+          >
+            <option value="">テーマを選択しない</option>
+            {userThemes.map((theme) => (
+              <option key={theme.id} value={theme.id}>
+                {theme.theme_name}
+              </option>
+            ))}
+          </select>
+          {userThemes.length === 0 && (
+            <p className="mt-1 text-xs text-gray-500">
+              💡 <a href="/settings" className="text-orange-600 hover:text-orange-700 underline">設定ページ</a>でテーマを作成すると、ここで選択できるようになります。
+            </p>
+          )}
         </div>
 
         {/* 3. 今日の学び or 気づき */}

--- a/frontend/src/components/MyPage.tsx
+++ b/frontend/src/components/MyPage.tsx
@@ -1,8 +1,8 @@
 import { useEffect, useState } from 'react';
+import { useAuth } from '../contexts/AuthContext';
+import { useExpandableText } from '../hooks/useExpandableText';
 import { isAmazonLink } from '../utils/amazonUtils';
 import { trackShare } from '../utils/analytics';
-import { useExpandableText } from '../hooks/useExpandableText';
-import { useAuth } from '../contexts/AuthContext';
 import BookIcon from './BookIcon';
 import ExpandableTextDisplay from './ExpandableTextDisplay';
 
@@ -30,6 +30,8 @@ function MyPage() {
   const [error, setError] = useState<string | null>(null);
   const [hoveredTooltip, setHoveredTooltip] = useState<number | null>(null);
   const [editingRecord, setEditingRecord] = useState<number | null>(null);
+  
+
 
   const [editFormData, setEditFormData] = useState<{
     title: string;
@@ -108,6 +110,8 @@ function MyPage() {
       setLoading(false);
     }
   };
+
+
 
   // 投稿削除処理
   const deleteRecord = async (id: number, title: string) => {
@@ -484,6 +488,8 @@ ${action}
           マイページ
         </h1>
       </div>
+
+
       
       {records.length === 0 ? (
         <div className="text-center py-12">

--- a/migrations/development/005-add-theme-id-to-reading-records.sql
+++ b/migrations/development/005-add-theme-id-to-reading-records.sql
@@ -1,0 +1,27 @@
+-- reading_recordsテーブルにtheme_idカラムを追加
+-- Issue #116: テーマベース読書記録統計機能のため
+
+-- 1. theme_idカラムを追加（NULLを許可、外部キー制約あり）
+ALTER TABLE reading_records 
+ADD COLUMN theme_id INTEGER;
+
+-- 2. 外部キー制約を追加
+ALTER TABLE reading_records 
+ADD CONSTRAINT fk_reading_records_theme_id 
+FOREIGN KEY (theme_id) REFERENCES writing_themes(id) 
+ON DELETE SET NULL;
+
+-- 3. インデックスを追加（テーマ別統計取得の高速化）
+CREATE INDEX idx_reading_records_theme_id ON reading_records(theme_id);
+
+-- 4. 複合インデックスを追加（ユーザー別・テーマ別統計取得の高速化）
+CREATE INDEX idx_reading_records_user_theme ON reading_records(user_id, theme_id);
+
+-- 5. 日付別統計用のインデックスを追加（created_atでソート）
+CREATE INDEX idx_reading_records_created_at ON reading_records(created_at);
+
+-- 確認用のクエリ
+-- SELECT column_name, data_type, is_nullable 
+-- FROM information_schema.columns 
+-- WHERE table_name = 'reading_records' 
+-- ORDER BY ordinal_position;

--- a/migrations/production/003-add-theme-id-to-reading-records.sql
+++ b/migrations/production/003-add-theme-id-to-reading-records.sql
@@ -1,0 +1,34 @@
+-- production環境用: reading_recordsテーブルにtheme_idカラムを追加
+-- Issue #116: テーマベース読書記録統計機能のため
+
+BEGIN;
+
+-- 1. theme_idカラムを追加（NULLを許可、外部キー制約あり）
+ALTER TABLE reading_records 
+ADD COLUMN theme_id INTEGER;
+
+-- 2. 外部キー制約を追加
+ALTER TABLE reading_records 
+ADD CONSTRAINT fk_reading_records_theme_id 
+FOREIGN KEY (theme_id) REFERENCES writing_themes(id) 
+ON DELETE SET NULL;
+
+-- 3. インデックスを追加（テーマ別統計取得の高速化）
+CREATE INDEX CONCURRENTLY idx_reading_records_theme_id ON reading_records(theme_id);
+
+-- 4. 複合インデックスを追加（ユーザー別・テーマ別統計取得の高速化）
+CREATE INDEX CONCURRENTLY idx_reading_records_user_theme ON reading_records(user_id, theme_id);
+
+-- 5. 日付別統計用のインデックスを追加（created_atでソート）
+CREATE INDEX CONCURRENTLY idx_reading_records_created_at ON reading_records(created_at);
+
+COMMIT;
+
+-- ロールバック用（緊急時）
+-- BEGIN;
+-- DROP INDEX IF EXISTS idx_reading_records_created_at;
+-- DROP INDEX IF EXISTS idx_reading_records_user_theme;
+-- DROP INDEX IF EXISTS idx_reading_records_theme_id;
+-- ALTER TABLE reading_records DROP CONSTRAINT IF EXISTS fk_reading_records_theme_id;
+-- ALTER TABLE reading_records DROP COLUMN IF EXISTS theme_id;
+-- COMMIT;


### PR DESCRIPTION
## 🎯 概要

テーマ別読書統計機能をダッシュボードに完全統合し、認証状態の永続化問題を解決しました。

## ✨ 主な変更点

### 🎨 UI/UX改善
- **ダッシュボード統合**: テーマ別読書統計をマイページからダッシュボードに移動
- **グラフ統一**: テーマ別日次推移グラフをメインの日次推移グラフと同じスタイルに統一
- **レイアウト最適化**: テーマ別統計セクションを日次推移グラフの下に配置
- **スタイル統一**: 累積読書記録数の表示スタイルを統一

### 🔧 機能改善
- **テーマ選択**: 「全てのテーマ」オプションを削除し、「未分類」をデフォルトに設定
- **期間統一**: テーマ別日次推移を30日から14日に変更（メイングラフと統一）
- **データ精度**: 未分類テーマのデータ表示を正確に修正

### 🔐 認証・セキュリティ
- **認証永続化**: ダッシュボードリロード時の認証状態維持を実装
- **初期化処理**: 認証状態の初期化完了を待つ処理を追加
- **エラーハンドリング**: 認証エラー時の適切な表示を改善

### 🗄️ データベース
- **マイグレーション**: テーマIDを読書記録テーブルに追加するマイグレーション
- **クエリ最適化**: テーマ別統計取得のSQLクエリを改善

## 🧪 テスト済み機能
- ✅ テーマ別読書統計の表示
- ✅ テーマ選択による統計更新
- ✅ 日次推移グラフの表示
- ✅ ページリロード時の認証状態維持
- ✅ 未分類テーマのデータ表示

## 📝 技術的詳細

### フロントエンド
- : テーマ別統計機能の統合
- : 認証状態の永続化
- 認証初期化状態の管理を追加

### バックエンド
- テーマ別統計APIの実装
- 日次推移データの取得API
- データベースクエリの最適化

## 🚀 デプロイメント
- 開発環境での動作確認済み
- Docker環境でのテスト完了

## 📋 チェックリスト
- [x] 機能実装
- [x] UI/UX改善
- [x] 認証問題の解決
- [x] テスト実行
- [x] コードレビュー準備

Closes #116