### PR TITLE
fix: テーマ更新API修正とダッシュボード・タイムラインのテーマ表示機能追加

### DIFF
--- a/backend/src/index.ts
+++ b/backend/src/index.ts
@@ -579,7 +579,7 @@ app.put('/api/reading-records/:id', async (req, res) => {
       return res.status(400).json({ message: 'Invalid ID' });
     }
 
-    const { title, link, reading_amount, learning, action, notes, containsSpoiler } = req.body;
+    const { title, link, reading_amount, learning, action, notes, containsSpoiler, theme_id } = req.body;
     const updateData: Partial<ReadingRecord> = {};
 
     if (title) updateData.title = title;
@@ -592,6 +592,7 @@ app.put('/api/reading-records/:id', async (req, res) => {
     if (action) updateData.action = action;
     if (notes !== undefined) updateData.notes = notes;
     if (containsSpoiler !== undefined) updateData.contains_spoiler = containsSpoiler;
+    if (theme_id !== undefined) updateData.theme_id = theme_id;
 
     const result = await updateReadingRecord(id, updateData);
     if (result.success) {

--- a/frontend/src/components/Dashboard.tsx
+++ b/frontend/src/components/Dashboard.tsx
@@ -15,6 +15,15 @@ interface ReadingRecord {
   user_email?: string;
   created_at: string;
   updated_at: string;
+  theme_id?: number | null;
+}
+
+interface WritingTheme {
+  id: number;
+  user_id: string;
+  theme_name: string;
+  created_at: string;
+  updated_at: string;
 }
 
 interface DailyRecord {
@@ -25,6 +34,7 @@ interface DailyRecord {
 function Dashboard() {
   const { token, isAuthenticated } = useAuth();
   const [records, setRecords] = useState<ReadingRecord[]>([]);
+  const [themes, setThemes] = useState<WritingTheme[]>([]);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
   const [dailyRecords, setDailyRecords] = useState<DailyRecord[]>([]);
@@ -43,6 +53,7 @@ function Dashboard() {
   useEffect(() => {
     if (authInitialized && isAuthenticated && token) {
       fetchRecords();
+      fetchThemes();
       fetchAllThemeStats();
       fetchDailyTrends(); // 初期表示時にも日次推移を取得
     }
@@ -87,6 +98,28 @@ function Dashboard() {
       setError('レコードの取得に失敗しました。');
     } finally {
       setLoading(false);
+    }
+  };
+
+  const fetchThemes = async () => {
+    try {
+      const API_BASE_URL = import.meta.env.VITE_API_BASE_URL || 'http://localhost:3001';
+      const response = await fetch(`${API_BASE_URL}/api/writing-themes`, {
+        headers: {
+          'Authorization': `Bearer ${token}`,
+        },
+      });
+
+      if (response.ok) {
+        const result = await response.json();
+        setThemes(result.data || []);
+      } else {
+        console.error('テーマの読み込みに失敗しました');
+        setThemes([]);
+      }
+    } catch (error) {
+      console.error('テーマの読み込みに失敗しました:', error);
+      setThemes([]);
     }
   };
 

--- a/frontend/src/components/Timeline.tsx
+++ b/frontend/src/components/Timeline.tsx
@@ -18,6 +18,15 @@ interface ReadingRecord {
   is_liked?: boolean;
   containsSpoiler?: boolean;
   user_email?: string;
+  theme_id?: number | null;
+}
+
+interface WritingTheme {
+  id: number;
+  user_id: string;
+  theme_name: string;
+  created_at: string;
+  updated_at: string;
 }
 
 interface UserSettings {
@@ -28,6 +37,7 @@ function Timeline() {
   const { token, user } = useAuth();
   const [records, setRecords] = useState<ReadingRecord[]>([]);
   const [filteredRecords, setFilteredRecords] = useState<ReadingRecord[]>([]);
+  const [themes, setThemes] = useState<WritingTheme[]>([]);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
   const [sessionId, setSessionId] = useState<string>('');
@@ -49,6 +59,7 @@ function Timeline() {
   useEffect(() => {
     if (token) {
       loadUserSettings();
+      fetchThemes();
     }
   }, [token]);
 
@@ -106,6 +117,28 @@ function Timeline() {
       }
     } catch (error) {
       console.error('設定の読み込みに失敗しました:', error);
+    }
+  };
+
+  const fetchThemes = async () => {
+    try {
+      const API_BASE_URL = import.meta.env.VITE_API_BASE_URL || 'http://localhost:3001';
+      const response = await fetch(`${API_BASE_URL}/api/writing-themes`, {
+        headers: {
+          'Authorization': `Bearer ${token}`,
+        },
+      });
+
+      if (response.ok) {
+        const result = await response.json();
+        setThemes(result.data || []);
+      } else {
+        console.error('テーマの読み込みに失敗しました');
+        setThemes([]);
+      }
+    } catch (error) {
+      console.error('テーマの読み込みに失敗しました:', error);
+      setThemes([]);
     }
   };
 
@@ -304,6 +337,20 @@ function Timeline() {
                     </span>
                   )}
                 </div>
+                
+                {/* テーマ表示 */}
+                {record.theme_id && (
+                  <div className="mb-2">
+                    {(() => {
+                      const theme = themes.find(t => t.id === record.theme_id);
+                      return theme ? (
+                        <span className="inline-flex items-center px-2 py-1 rounded-full text-xs font-medium bg-purple-100 text-purple-800">
+                          🎯 {theme.theme_name}
+                        </span>
+                      ) : null;
+                    })()}
+                  </div>
+                )}
                 
                 {/* 読んだ量の丸といいねボタン */}
                 <div className="flex items-center space-x-2 mb-2">


### PR DESCRIPTION
- backend/src/index.ts: PUT /api/reading-records/:id でtheme_id処理を追加
- 編集時にtheme_idがAPIで無視されていた問題を修正
- Dashboard.tsx: ReadingRecordインターフェースにtheme_id追加、テーマ一覧取得機能実装
- Timeline.tsx: ReadingRecordインターフェースにtheme_id追加、テーマバッジ表示機能実装
- 本番環境でのテーマ紫色バッジ表示問題を修正

🤖 Generated with [Claude Code](https://claude.ai/code)