### PR TITLE
fix: ハンバーガーメニューの「読む（入力画面）」を「メモ（入力画面）」に変更

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -101,7 +101,7 @@ function AppContent() {
                     onClick={() => setIsMenuOpen(false)}
                     className="block px-4 py-3 text-gray-700 hover:bg-orange-50 hover:text-orange-700 transition-colors"
                   >
-                    📖 読む（入力画面）
+                    📝 メモ（入力画面）
                   </Link>
                   <Link
                     to="/draft-output"


### PR DESCRIPTION
## Summary
- Issue #139に対応
- ハンバーガーメニューの表示テキストを「📖 読む（入力画面）」から「📝 メモ（入力画面）」に変更
- アイコンも読書からメモに適切に変更

## Test plan
- [x] ローカル環境でハンバーガーメニューの表示を確認
- [x] メニュー項目が正しく「📝 メモ（入力画面）」と表示されることを確認
- [x] メニュー機能が正常に動作することを確認

🤖 Generated with [Claude Code](https://claude.ai/code)