### PR TITLE
feat: 明日の小さなアクションを任意項目にする (Issue #110)

### DIFF
--- a/backend/src/database.ts
+++ b/backend/src/database.ts
@@ -36,7 +36,7 @@ export interface ReadingRecord {
   link?: string;
   reading_amount: string;
   learning: string;
-  action: string;
+  action?: string;
   notes?: string;
   is_not_book?: boolean;
   custom_link?: string;

--- a/frontend/src/components/Dashboard.tsx
+++ b/frontend/src/components/Dashboard.tsx
@@ -9,7 +9,7 @@ interface ReadingRecord {
   link?: string;
   reading_amount: string;
   learning: string;
-  action: string;
+  action?: string;
   notes?: string;
   user_id?: string;
   user_email?: string;

--- a/frontend/src/components/InputForm.tsx
+++ b/frontend/src/components/InputForm.tsx
@@ -8,7 +8,7 @@ interface FormData {
   title: string;
   readingAmount: string;
   learning: string;
-  action: string;
+  action?: string;
   notes: string;
   isNotBook: boolean;
   customLink: string;
@@ -800,21 +800,23 @@ function InputForm() {
           />
         </div>
 
-        {/* 4. 明日の小さなアクション */}
+        {/* 4. 明日の小さなアクション（任意） */}
         <div>
           <label htmlFor="action" className="block text-sm font-medium text-gray-700 mb-2">
-            4. 明日の小さなアクション
+            4. 明日の小さなアクション <span className="text-xs text-gray-500">（任意）</span>
           </label>
           <textarea
             id="action"
             name="action"
             value={formData.action}
             onChange={handleInputChange}
-            placeholder="例：「朝会で相手の話をさえぎらずに聞く」"
+            placeholder="例：「朝会で相手の話をさえぎらずに聞く」（学ぶだけの場合は空欄でもOK）"
             rows={3}
             className="w-full px-4 py-3 border border-gray-300 rounded-lg focus:ring-2 focus:ring-orange-500 focus:border-transparent transition-colors resize-none"
-            required
           />
+          <p className="text-xs text-gray-500 mt-1">
+            学ぶだけの場合は空欄でも問題ありません
+          </p>
         </div>
 
         {/* 5. 備考（マイページでのみ表示） */}
@@ -881,7 +883,7 @@ function InputForm() {
           <button
             type="button"
             onClick={() => {
-              if (formData.action.trim()) {
+              if (formData.action?.trim()) {
                 const prompt = `以下の読書から得た学びとアクションについて、学んだ内容の整理と具体的で実行可能なアクションに深掘りしてください。
 
 【読んだ本】
@@ -918,7 +920,7 @@ ${formData.action}
                 alert('明日の小さなアクションを入力してからお試しください。');
               }
             }}
-            disabled={!formData.action.trim()}
+            disabled={!formData.action?.trim()}
             className="w-full bg-gradient-to-r from-purple-500 to-indigo-500 text-white font-semibold py-3 px-6 rounded-lg hover:from-purple-600 hover:to-indigo-600 focus:ring-4 focus:ring-purple-300 transition-all duration-200 disabled:opacity-50 disabled:cursor-not-allowed flex items-center justify-center space-x-2"
           >
             <svg className="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">

--- a/frontend/src/components/MyPage.tsx
+++ b/frontend/src/components/MyPage.tsx
@@ -200,7 +200,7 @@ function MyPage() {
       title: record.title,
       reading_amount: record.reading_amount,
       learning: record.learning,
-      action: record.action,
+      action: record.action || '',
       notes: record.notes || '',
       link: record.link || '',
       containsSpoiler: record.containsSpoiler || false,
@@ -624,7 +624,7 @@ ${action}
                     </svg>
                   </button>
                   <button
-                    onClick={() => openGoogleTodo(record.action, record.title)}
+                    onClick={() => openGoogleTodo(record.action || '', record.title)}
                     className="text-green-500 hover:text-green-700 hover:bg-green-50 p-1 rounded-full transition-colors"
                     title="Google TODOに追加"
                   >
@@ -633,8 +633,8 @@ ${action}
                     </svg>
                   </button>
                   {(() => {
-                    const text = generateSocialText(record.learning, record.action, record.title, record.link);
-                    const isWithinCharLimit = isWithinLimit(record.learning, record.action);
+                    const text = generateSocialText(record.learning, record.action || '', record.title, record.link);
+                    const isWithinCharLimit = isWithinLimit(record.learning, record.action || '');
                     
                     // デバッグ用ログ
                     console.log('シェアテキスト:', {
@@ -651,8 +651,8 @@ ${action}
                     return (
                       <button
                         onClick={() => isWithinCharLimit 
-                          ? shareOnTwitter(record.learning, record.action, record.title, record.link)
-                          : shareOnNote(record.learning, record.action, record.title, record.link)
+                          ? shareOnTwitter(record.learning, record.action || '', record.title, record.link)
+                          : shareOnNote(record.learning, record.action || '', record.title, record.link)
                         }
                         className={`p-1 rounded-full transition-colors ${
                           isWithinCharLimit 
@@ -668,7 +668,7 @@ ${action}
                     );
                   })()}
                   <button
-                    onClick={() => openChatGPT(record.action, record.learning, record.title)}
+                    onClick={() => openChatGPT(record.action || '', record.learning, record.title)}
                     className="text-purple-500 hover:text-purple-700 hover:bg-purple-50 p-1 rounded-full transition-colors"
                     title="ChatGPTで学びとアクションを整理"
                   >
@@ -938,19 +938,21 @@ ${action}
               />
 
               {/* アクション */}
-              <ExpandableTextDisplay
-                recordId={record.id}
-                field="action"
-                text={record.action}
-                displayText={getDisplayText(record.id, 'action', record.action)}
-                isTextLong={isTextLong(record.action)}
-                isExpanded={expandedTexts[record.id]?.action || false}
-                onToggle={() => toggleTextExpansion(record.id, 'action')}
-                bgColor="bg-green-50"
-                borderColor="border-green-400"
-                icon="🎯"
-                title="明日のアクション"
-              />
+              {record.action && (
+                <ExpandableTextDisplay
+                  recordId={record.id}
+                  field="action"
+                  text={record.action}
+                  displayText={getDisplayText(record.id, 'action', record.action)}
+                  isTextLong={isTextLong(record.action)}
+                  isExpanded={expandedTexts[record.id]?.action || false}
+                  onToggle={() => toggleTextExpansion(record.id, 'action')}
+                  bgColor="bg-green-50"
+                  borderColor="border-green-400"
+                  icon="🎯"
+                  title="明日のアクション"
+                />
+              )}
 
               {/* 備考（マイページでのみ表示） */}
               {record.notes && (

--- a/frontend/src/components/MyPage.tsx
+++ b/frontend/src/components/MyPage.tsx
@@ -12,7 +12,7 @@ interface ReadingRecord {
   link?: string;
   reading_amount: string;
   learning: string;
-  action: string;
+  action?: string;
   notes?: string;
   user_id?: string;
   user_email?: string;

--- a/frontend/src/components/Timeline.tsx
+++ b/frontend/src/components/Timeline.tsx
@@ -1,7 +1,7 @@
 import { useEffect, useState } from 'react';
 import { useAuth } from '../contexts/AuthContext';
-import { isAmazonLink } from '../utils/amazonUtils';
 import { useExpandableText } from '../hooks/useExpandableText';
+import { isAmazonLink } from '../utils/amazonUtils';
 import BookIcon from './BookIcon';
 import ExpandableTextDisplay from './ExpandableTextDisplay';
 
@@ -11,7 +11,7 @@ interface ReadingRecord {
   link?: string;
   reading_amount: string;
   learning: string;
-  action: string;
+  action?: string;
   created_at: string;
   updated_at: string;
   like_count?: number | string;
@@ -411,19 +411,21 @@ function Timeline() {
               />
 
               {/* アクション */}
-              <ExpandableTextDisplay
-                recordId={record.id}
-                field="action"
-                text={record.action}
-                displayText={getDisplayText(record.id, 'action', record.action)}
-                isTextLong={isTextLong(record.action)}
-                isExpanded={expandedTexts[record.id]?.action || false}
-                onToggle={() => toggleTextExpansion(record.id, 'action')}
-                bgColor="bg-green-50"
-                borderColor="border-green-400"
-                icon="🎯"
-                title="明日のアクション"
-              />
+              {record.action && (
+                <ExpandableTextDisplay
+                  recordId={record.id}
+                  field="action"
+                  text={record.action}
+                  displayText={getDisplayText(record.id, 'action', record.action)}
+                  isTextLong={isTextLong(record.action)}
+                  isExpanded={expandedTexts[record.id]?.action || false}
+                  onToggle={() => toggleTextExpansion(record.id, 'action')}
+                  bgColor="bg-green-50"
+                  borderColor="border-green-400"
+                  icon="🎯"
+                  title="明日のアクション"
+                />
+              )}
             </div>
           ))}
         </div>

--- a/migrations/development/010-make-action-optional.sql
+++ b/migrations/development/010-make-action-optional.sql
@@ -1,0 +1,8 @@
+-- Issue #110: 明日の小さなアクションを任意項目にする
+-- actionフィールドをNOT NULLからNULL許可に変更
+
+-- 既存のNOT NULL制約を削除
+ALTER TABLE reading_records ALTER COLUMN action DROP NOT NULL;
+
+-- コメントを追加
+COMMENT ON COLUMN reading_records.action IS '明日の小さなアクション（任意項目）'; 

--- a/migrations/production/008-make-action-optional.sql
+++ b/migrations/production/008-make-action-optional.sql
@@ -1,0 +1,8 @@
+-- Issue #110: 明日の小さなアクションを任意項目にする
+-- actionフィールドをNOT NULLからNULL許可に変更
+
+-- 既存のNOT NULL制約を削除
+ALTER TABLE reading_records ALTER COLUMN action DROP NOT NULL;
+
+-- コメントを追加
+COMMENT ON COLUMN reading_records.action IS '明日の小さなアクション（任意項目）'; 


### PR DESCRIPTION
## 概要

Issue #110で要求されていた「明日の小さなアクションを任意項目にする」機能を実装しました。

## 背景

学ぶだけのケースがけっこうあるため、アクションを必ずしも入力する必要がないようにする。

## 修正内容

### ��️ データベース
- **マイグレーション**: フィールドをから許可に変更
- **コメント**: フィールドに「明日の小さなアクション（任意項目）」のコメントを追加

### 🔧 バックエンド
- **型定義**: インターフェースでフィールドを任意項目に変更
- **データ処理**: フィールドがの場合の適切な処理

### 🎨 フロントエンド
- **InputForm**: 
  - ラベルに「（任意）」を追加
  - プレースホルダーに「学ぶだけの場合は空欄でもOK」を追加
  - 説明文に「学ぶだけの場合は空欄でも問題ありません」を追加
  - 属性を削除
- **Timeline**: フィールドが存在する場合のみ表示
- **MyPage**: フィールドが存在する場合のみ表示
- **Dashboard**: 型定義を修正

### 🛠️ 技術的改善
- **TypeScript**: すべてのコンポーネントでフィールドの処理を追加
- **エラーハンドリング**: 適切なフォールバック処理を実装

## 動作確認

- [x] アクションフィールドを空欄で投稿可能
- [x] アクションが入力されている場合は従来通り表示
- [x] アクションが空欄の場合は表示されない
- [x] 編集時にアクションを追加/削除可能
- [x] シェア機能でアクションが空欄の場合の処理

## マイグレーション

開発環境と本番環境用のマイグレーションスクリプトを作成済み：
- 
- 

Closes #110