### PR TITLE
feat: Add place selection link to hamburger menu (Issue #148)

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -174,6 +174,17 @@ function AppContent() {
                 </button>
               )}
               
+              <div className="border-t border-orange-100 mt-2 pt-2">
+                <a
+                  href="https://ichidan-dokusho-place-frontend.onrender.com/"
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  onClick={() => setIsMenuOpen(false)}
+                  className="block px-4 py-3 text-gray-700 hover:bg-orange-50 hover:text-orange-700 transition-colors"
+                >
+                  📍 場所を選ぶ
+                </a>
+              </div>
 
             </div>
           </div>


### PR DESCRIPTION
- Add '場所を選ぶ' link at bottom of hamburger menu
- Link navigates to ichidan-dokusho-place-frontend.onrender.com
- Includes visual separator and consistent styling
- Opens in new tab with proper security attributes