### PR TITLE
Create tag page with book list

### DIFF
--- a/backend/src/index.ts
+++ b/backend/src/index.ts
@@ -15,6 +15,7 @@ import {
     getAllBooks,
     getAllTags,
     getAllThemeReadingStats,
+    getBooksByTagName,
     getDailyThemeReadingTrends,
     getPromptTemplate,
     getReadingRecordById,
@@ -1530,6 +1531,23 @@ app.get('/api/tags', async (req, res) => {
     }
   } catch (error) {
     console.error('Get tags error:', error);
+    res.status(500).json({ error: 'Internal server error' });
+  }
+});
+
+// タグ名で書籍取得API
+app.get('/api/books/tag/:tagName', async (req, res) => {
+  try {
+    const { tagName } = req.params;
+    const result = await getBooksByTagName(decodeURIComponent(tagName));
+    
+    if (result.success) {
+      res.json(result.data);
+    } else {
+      res.status(500).json({ error: result.error });
+    }
+  } catch (error) {
+    console.error('Get books by tag error:', error);
     res.status(500).json({ error: 'Internal server error' });
   }
 });

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -13,6 +13,8 @@ import QAPage from './components/QAPage';
 import ReadingPage from './components/ReadingPage';
 import SelectionScreen from './components/SelectionScreen';
 import SettingsPage from './components/SettingsPage';
+import TagPage from './components/TagPage';
+import TagsListPage from './components/TagsListPage';
 import BottomNavigationBar from './components/BottomNavigationBar';
 import { AuthProvider, useAuth } from './contexts/AuthContext';
 
@@ -128,6 +130,14 @@ function AppContent() {
                 ❓ Q&A
               </Link>
               
+              <Link
+                to="/tags"
+                onClick={() => setIsMenuOpen(false)}
+                className="block px-4 py-3 text-gray-700 hover:bg-orange-50 hover:text-orange-700 transition-colors"
+              >
+                🏷️ タグ一覧
+              </Link>
+              
               <div className="border-t border-orange-100 mt-2 pt-2">
                 <a
                   href="https://ichidan-dokusho-place-frontend.onrender.com/"
@@ -222,6 +232,16 @@ function AppContent() {
           </div>
         } />
         <Route path="/admin/register" element={<BookRegisterPage />} />
+        <Route path="/tags" element={
+          <div className="container mx-auto px-1 sm:px-4 pt-0 pb-2 sm:pb-8 max-w-2xl w-full overflow-x-hidden">
+            <TagsListPage />
+          </div>
+        } />
+        <Route path="/:tag" element={
+          <div className="container mx-auto px-1 sm:px-4 pt-0 pb-2 sm:pb-8 max-w-2xl w-full overflow-x-hidden">
+            <TagPage />
+          </div>
+        } />
 
       </Routes>
       

--- a/frontend/src/components/TagPage.tsx
+++ b/frontend/src/components/TagPage.tsx
@@ -1,0 +1,200 @@
+import React, { useEffect, useState } from 'react';
+import { useParams, useNavigate } from 'react-router-dom';
+import { findOriginalTagName } from '../utils/romanization';
+
+interface Tag {
+  id: number;
+  name: string;
+  created_at: string;
+}
+
+interface Book {
+  id: number;
+  title: string;
+  amazon_link: string;
+  created_at: string;
+  updated_at: string;
+  tags: Tag[];
+}
+
+const TagPage: React.FC = () => {
+  const { tag } = useParams<{ tag: string }>();
+  const navigate = useNavigate();
+  const [books, setBooks] = useState<Book[]>([]);
+  const [allTags, setAllTags] = useState<Tag[]>([]);
+  const [originalTagName, setOriginalTagName] = useState<string>('');
+  const [isLoading, setIsLoading] = useState(true);
+  const [error, setError] = useState<string>('');
+
+  const API_BASE_URL = import.meta.env.VITE_API_BASE_URL || 'http://localhost:3001';
+
+  useEffect(() => {
+    const fetchData = async () => {
+      if (!tag) return;
+
+      try {
+        setIsLoading(true);
+        setError('');
+
+        // まず全てのタグを取得して、ローマ字から元のタグ名を逆引き
+        const tagsResponse = await fetch(`${API_BASE_URL}/api/tags`);
+        if (!tagsResponse.ok) {
+          throw new Error('タグの取得に失敗しました');
+        }
+        const tagsData = await tagsResponse.json();
+        setAllTags(tagsData);
+
+        // ローマ字から元のタグ名を見つける
+        const originalTag = findOriginalTagName(tag, tagsData);
+        if (!originalTag) {
+          setError('指定されたタグが見つかりません');
+          return;
+        }
+        setOriginalTagName(originalTag);
+
+        // そのタグの書籍を取得
+        const booksResponse = await fetch(`${API_BASE_URL}/api/books/tag/${encodeURIComponent(originalTag)}`);
+        if (!booksResponse.ok) {
+          throw new Error('書籍の取得に失敗しました');
+        }
+        const booksData = await booksResponse.json();
+        setBooks(booksData);
+
+      } catch (err) {
+        console.error('Error fetching data:', err);
+        setError(err instanceof Error ? err.message : '不明なエラーが発生しました');
+      } finally {
+        setIsLoading(false);
+      }
+    };
+
+    fetchData();
+  }, [tag, API_BASE_URL]);
+
+  const handleBookClick = (amazonLink: string) => {
+    window.open(amazonLink, '_blank', 'noopener,noreferrer');
+  };
+
+  if (isLoading) {
+    return (
+      <div className="min-h-screen bg-gradient-to-br from-amber-50 via-orange-50 to-yellow-50 flex items-center justify-center">
+        <div className="text-center">
+          <div className="animate-spin rounded-full h-12 w-12 border-b-2 border-orange-600 mx-auto mb-4"></div>
+          <p className="text-gray-600">読み込み中...</p>
+        </div>
+      </div>
+    );
+  }
+
+  if (error) {
+    return (
+      <div className="min-h-screen bg-gradient-to-br from-amber-50 via-orange-50 to-yellow-50 flex items-center justify-center">
+        <div className="text-center">
+          <div className="text-red-500 text-xl mb-4">⚠️</div>
+          <p className="text-gray-700 mb-4">{error}</p>
+          <button
+            onClick={() => navigate('/mypage')}
+            className="bg-orange-600 text-white px-4 py-2 rounded-lg hover:bg-orange-700 transition-colors"
+          >
+            マイページに戻る
+          </button>
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <div className="min-h-screen bg-gradient-to-br from-amber-50 via-orange-50 to-yellow-50">
+      <div className="container mx-auto px-4 py-8 max-w-4xl">
+        {/* ヘッダー */}
+        <div className="mb-8">
+          <button
+            onClick={() => navigate(-1)}
+            className="flex items-center text-orange-600 hover:text-orange-700 mb-4 transition-colors"
+          >
+            <svg className="w-5 h-5 mr-2" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+              <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M15 19l-7-7 7-7" />
+            </svg>
+            戻る
+          </button>
+          
+          <div className="bg-white/80 backdrop-blur-sm rounded-xl p-6 shadow-lg border border-orange-100">
+            <div className="flex items-center mb-2">
+              <span className="text-2xl mr-3">🏷️</span>
+              <h1 className="text-2xl font-bold text-gray-800">{originalTagName}</h1>
+            </div>
+            <p className="text-gray-600">
+              {books.length}冊の書籍が登録されています
+            </p>
+          </div>
+        </div>
+
+        {/* 書籍一覧 */}
+        {books.length === 0 ? (
+          <div className="text-center py-12">
+            <div className="text-6xl mb-4">📚</div>
+            <p className="text-gray-600 text-lg">このタグに登録された書籍はまだありません</p>
+          </div>
+        ) : (
+          <div className="space-y-4">
+            {books.map((book) => (
+              <div
+                key={book.id}
+                onClick={() => handleBookClick(book.amazon_link)}
+                className="bg-white/80 backdrop-blur-sm rounded-xl p-6 shadow-lg border border-orange-100 hover:shadow-xl hover:bg-white/90 transition-all duration-200 cursor-pointer group"
+              >
+                <div className="flex items-start space-x-4">
+                  {/* 書籍アイコン */}
+                  <div className="flex-shrink-0">
+                    <div className="w-16 h-20 bg-gradient-to-br from-orange-400 to-orange-600 rounded-lg flex items-center justify-center text-white text-2xl shadow-md group-hover:shadow-lg transition-shadow">
+                      📖
+                    </div>
+                  </div>
+                  
+                  {/* 書籍情報 */}
+                  <div className="flex-1 min-w-0">
+                    <h3 className="text-lg font-semibold text-gray-800 mb-2 group-hover:text-orange-700 transition-colors">
+                      {book.title}
+                    </h3>
+                    
+                    {/* タグ一覧 */}
+                    <div className="flex flex-wrap gap-2 mb-3">
+                      {book.tags.map((bookTag) => (
+                        <span
+                          key={bookTag.id}
+                          className={`px-3 py-1 rounded-full text-sm font-medium transition-colors ${
+                            bookTag.name === originalTagName
+                              ? 'bg-orange-200 text-orange-800'
+                              : 'bg-gray-100 text-gray-600 hover:bg-gray-200'
+                          }`}
+                        >
+                          {bookTag.name}
+                        </span>
+                      ))}
+                    </div>
+                    
+                    {/* 登録日 */}
+                    <p className="text-sm text-gray-500">
+                      登録日: {new Date(book.created_at).toLocaleDateString('ja-JP')}
+                    </p>
+                  </div>
+                  
+                  {/* 外部リンクアイコン */}
+                  <div className="flex-shrink-0">
+                    <div className="w-8 h-8 rounded-full bg-orange-100 flex items-center justify-center group-hover:bg-orange-200 transition-colors">
+                      <svg className="w-4 h-4 text-orange-600" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                        <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M10 6H6a2 2 0 00-2 2v10a2 2 0 002 2h10a2 2 0 002-2v-4M14 4h6m0 0v6m0-6L10 14" />
+                      </svg>
+                    </div>
+                  </div>
+                </div>
+              </div>
+            ))}
+          </div>
+        )}
+      </div>
+    </div>
+  );
+};
+
+export default TagPage;

--- a/frontend/src/components/TagPage.tsx
+++ b/frontend/src/components/TagPage.tsx
@@ -21,7 +21,6 @@ const TagPage: React.FC = () => {
   const { tag } = useParams<{ tag: string }>();
   const navigate = useNavigate();
   const [books, setBooks] = useState<Book[]>([]);
-  const [allTags, setAllTags] = useState<Tag[]>([]);
   const [originalTagName, setOriginalTagName] = useState<string>('');
   const [isLoading, setIsLoading] = useState(true);
   const [error, setError] = useState<string>('');
@@ -42,7 +41,6 @@ const TagPage: React.FC = () => {
           throw new Error('タグの取得に失敗しました');
         }
         const tagsData = await tagsResponse.json();
-        setAllTags(tagsData);
 
         // ローマ字から元のタグ名を見つける
         const originalTag = findOriginalTagName(tag, tagsData);

--- a/frontend/src/components/TagsListPage.tsx
+++ b/frontend/src/components/TagsListPage.tsx
@@ -1,0 +1,146 @@
+import React, { useEffect, useState } from 'react';
+import { useNavigate } from 'react-router-dom';
+import { romanizeTagName } from '../utils/romanization';
+
+interface Tag {
+  id: number;
+  name: string;
+  created_at: string;
+}
+
+const TagsListPage: React.FC = () => {
+  const navigate = useNavigate();
+  const [tags, setTags] = useState<Tag[]>([]);
+  const [isLoading, setIsLoading] = useState(true);
+  const [error, setError] = useState<string>('');
+
+  const API_BASE_URL = import.meta.env.VITE_API_BASE_URL || 'http://localhost:3001';
+
+  useEffect(() => {
+    const fetchTags = async () => {
+      try {
+        setIsLoading(true);
+        setError('');
+
+        const response = await fetch(`${API_BASE_URL}/api/tags`);
+        if (!response.ok) {
+          throw new Error('タグの取得に失敗しました');
+        }
+        const data = await response.json();
+        setTags(data);
+
+      } catch (err) {
+        console.error('Error fetching tags:', err);
+        setError(err instanceof Error ? err.message : '不明なエラーが発生しました');
+      } finally {
+        setIsLoading(false);
+      }
+    };
+
+    fetchTags();
+  }, [API_BASE_URL]);
+
+  const handleTagClick = (tagName: string) => {
+    const romanizedTag = romanizeTagName(tagName);
+    navigate(`/${romanizedTag}`);
+  };
+
+  if (isLoading) {
+    return (
+      <div className="min-h-screen bg-gradient-to-br from-amber-50 via-orange-50 to-yellow-50 flex items-center justify-center">
+        <div className="text-center">
+          <div className="animate-spin rounded-full h-12 w-12 border-b-2 border-orange-600 mx-auto mb-4"></div>
+          <p className="text-gray-600">読み込み中...</p>
+        </div>
+      </div>
+    );
+  }
+
+  if (error) {
+    return (
+      <div className="min-h-screen bg-gradient-to-br from-amber-50 via-orange-50 to-yellow-50 flex items-center justify-center">
+        <div className="text-center">
+          <div className="text-red-500 text-xl mb-4">⚠️</div>
+          <p className="text-gray-700 mb-4">{error}</p>
+          <button
+            onClick={() => navigate('/mypage')}
+            className="bg-orange-600 text-white px-4 py-2 rounded-lg hover:bg-orange-700 transition-colors"
+          >
+            マイページに戻る
+          </button>
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <div className="min-h-screen bg-gradient-to-br from-amber-50 via-orange-50 to-yellow-50">
+      <div className="container mx-auto px-4 py-8 max-w-4xl">
+        {/* ヘッダー */}
+        <div className="mb-8">
+          <button
+            onClick={() => navigate(-1)}
+            className="flex items-center text-orange-600 hover:text-orange-700 mb-4 transition-colors"
+          >
+            <svg className="w-5 h-5 mr-2" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+              <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M15 19l-7-7 7-7" />
+            </svg>
+            戻る
+          </button>
+          
+          <div className="bg-white/80 backdrop-blur-sm rounded-xl p-6 shadow-lg border border-orange-100">
+            <div className="flex items-center mb-2">
+              <span className="text-2xl mr-3">🏷️</span>
+              <h1 className="text-2xl font-bold text-gray-800">タグ一覧</h1>
+            </div>
+            <p className="text-gray-600">
+              {tags.length}個のタグが登録されています
+            </p>
+          </div>
+        </div>
+
+        {/* タグ一覧 */}
+        {tags.length === 0 ? (
+          <div className="text-center py-12">
+            <div className="text-6xl mb-4">🏷️</div>
+            <p className="text-gray-600 text-lg">まだタグが登録されていません</p>
+          </div>
+        ) : (
+          <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-4">
+            {tags.map((tag) => (
+              <div
+                key={tag.id}
+                onClick={() => handleTagClick(tag.name)}
+                className="bg-white/80 backdrop-blur-sm rounded-xl p-6 shadow-lg border border-orange-100 hover:shadow-xl hover:bg-white/90 transition-all duration-200 cursor-pointer group"
+              >
+                <div className="flex items-center justify-between">
+                  <div className="flex items-center space-x-3">
+                    <div className="w-10 h-10 bg-gradient-to-br from-orange-400 to-orange-600 rounded-lg flex items-center justify-center text-white text-lg shadow-md group-hover:shadow-lg transition-shadow">
+                      🏷️
+                    </div>
+                    <div>
+                      <h3 className="text-lg font-semibold text-gray-800 group-hover:text-orange-700 transition-colors">
+                        {tag.name}
+                      </h3>
+                      <p className="text-sm text-gray-500">
+                        /{romanizeTagName(tag.name)}
+                      </p>
+                    </div>
+                  </div>
+                  
+                  <div className="w-6 h-6 rounded-full bg-orange-100 flex items-center justify-center group-hover:bg-orange-200 transition-colors">
+                    <svg className="w-3 h-3 text-orange-600" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                      <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M9 5l7 7-7 7" />
+                    </svg>
+                  </div>
+                </div>
+              </div>
+            ))}
+          </div>
+        )}
+      </div>
+    </div>
+  );
+};
+
+export default TagsListPage;

--- a/frontend/src/utils/romanization.ts
+++ b/frontend/src/utils/romanization.ts
@@ -1,0 +1,122 @@
+// ひらがなとカタカナをローマ字に変換するマッピング
+const hiraganaToRomaji: { [key: string]: string } = {
+  'あ': 'a', 'い': 'i', 'う': 'u', 'え': 'e', 'お': 'o',
+  'か': 'ka', 'き': 'ki', 'く': 'ku', 'け': 'ke', 'こ': 'ko',
+  'が': 'ga', 'ぎ': 'gi', 'ぐ': 'gu', 'げ': 'ge', 'ご': 'go',
+  'さ': 'sa', 'し': 'shi', 'す': 'su', 'せ': 'se', 'そ': 'so',
+  'ざ': 'za', 'じ': 'ji', 'ず': 'zu', 'ぜ': 'ze', 'ぞ': 'zo',
+  'た': 'ta', 'ち': 'chi', 'つ': 'tsu', 'て': 'te', 'と': 'to',
+  'だ': 'da', 'ぢ': 'ji', 'づ': 'zu', 'で': 'de', 'ど': 'do',
+  'な': 'na', 'に': 'ni', 'ぬ': 'nu', 'ね': 'ne', 'の': 'no',
+  'は': 'ha', 'ひ': 'hi', 'ふ': 'fu', 'へ': 'he', 'ほ': 'ho',
+  'ば': 'ba', 'び': 'bi', 'ぶ': 'bu', 'べ': 'be', 'ぼ': 'bo',
+  'ぱ': 'pa', 'ぴ': 'pi', 'ぷ': 'pu', 'ぺ': 'pe', 'ぽ': 'po',
+  'ま': 'ma', 'み': 'mi', 'む': 'mu', 'め': 'me', 'も': 'mo',
+  'や': 'ya', 'ゆ': 'yu', 'よ': 'yo',
+  'ら': 'ra', 'り': 'ri', 'る': 'ru', 'れ': 're', 'ろ': 'ro',
+  'わ': 'wa', 'ゐ': 'wi', 'ゑ': 'we', 'を': 'wo', 'ん': 'n',
+  'ー': '-', 'っ': 'tsu',
+  // 拗音
+  'きゃ': 'kya', 'きゅ': 'kyu', 'きょ': 'kyo',
+  'しゃ': 'sha', 'しゅ': 'shu', 'しょ': 'sho',
+  'ちゃ': 'cha', 'ちゅ': 'chu', 'ちょ': 'cho',
+  'にゃ': 'nya', 'にゅ': 'nyu', 'にょ': 'nyo',
+  'ひゃ': 'hya', 'ひゅ': 'hyu', 'ひょ': 'hyo',
+  'みゃ': 'mya', 'みゅ': 'myu', 'みょ': 'myo',
+  'りゃ': 'rya', 'りゅ': 'ryu', 'りょ': 'ryo',
+  'ぎゃ': 'gya', 'ぎゅ': 'gyu', 'ぎょ': 'gyo',
+  'じゃ': 'ja', 'じゅ': 'ju', 'じょ': 'jo',
+  'びゃ': 'bya', 'びゅ': 'byu', 'びょ': 'byo',
+  'ぴゃ': 'pya', 'ぴゅ': 'pyu', 'ぴょ': 'pyo'
+};
+
+const katakanaToRomaji: { [key: string]: string } = {
+  'ア': 'a', 'イ': 'i', 'ウ': 'u', 'エ': 'e', 'オ': 'o',
+  'カ': 'ka', 'キ': 'ki', 'ク': 'ku', 'ケ': 'ke', 'コ': 'ko',
+  'ガ': 'ga', 'ギ': 'gi', 'グ': 'gu', 'ゲ': 'ge', 'ゴ': 'go',
+  'サ': 'sa', 'シ': 'shi', 'ス': 'su', 'セ': 'se', 'ソ': 'so',
+  'ザ': 'za', 'ジ': 'ji', 'ズ': 'zu', 'ゼ': 'ze', 'ゾ': 'zo',
+  'タ': 'ta', 'チ': 'chi', 'ツ': 'tsu', 'テ': 'te', 'ト': 'to',
+  'ダ': 'da', 'ヂ': 'ji', 'ヅ': 'zu', 'デ': 'de', 'ド': 'do',
+  'ナ': 'na', 'ニ': 'ni', 'ヌ': 'nu', 'ネ': 'ne', 'ノ': 'no',
+  'ハ': 'ha', 'ヒ': 'hi', 'フ': 'fu', 'ヘ': 'he', 'ホ': 'ho',
+  'バ': 'ba', 'ビ': 'bi', 'ブ': 'bu', 'ベ': 'be', 'ボ': 'bo',
+  'パ': 'pa', 'ピ': 'pi', 'プ': 'pu', 'ペ': 'pe', 'ポ': 'po',
+  'マ': 'ma', 'ミ': 'mi', 'ム': 'mu', 'メ': 'me', 'モ': 'mo',
+  'ヤ': 'ya', 'ユ': 'yu', 'ヨ': 'yo',
+  'ラ': 'ra', 'リ': 'ri', 'ル': 'ru', 'レ': 're', 'ロ': 'ro',
+  'ワ': 'wa', 'ヰ': 'wi', 'ヱ': 'we', 'ヲ': 'wo', 'ン': 'n',
+  'ー': '-', 'ッ': 'tsu',
+  // 拗音
+  'キャ': 'kya', 'キュ': 'kyu', 'キョ': 'kyo',
+  'シャ': 'sha', 'シュ': 'shu', 'ショ': 'sho',
+  'チャ': 'cha', 'チュ': 'chu', 'チョ': 'cho',
+  'ニャ': 'nya', 'ニュ': 'nyu', 'ニョ': 'nyo',
+  'ヒャ': 'hya', 'ヒュ': 'hyu', 'ヒョ': 'hyo',
+  'ミャ': 'mya', 'ミュ': 'myu', 'ミョ': 'myo',
+  'リャ': 'rya', 'リュ': 'ryu', 'リョ': 'ryo',
+  'ギャ': 'gya', 'ギュ': 'gyu', 'ギョ': 'gyo',
+  'ジャ': 'ja', 'ジュ': 'ju', 'ジョ': 'jo',
+  'ビャ': 'bya', 'ビュ': 'byu', 'ビョ': 'byo',
+  'ピャ': 'pya', 'ピュ': 'pyu', 'ピョ': 'pyo'
+};
+
+/**
+ * 日本語のタグ名をローマ字に変換してURL-friendlyにする
+ * @param tagName 日本語のタグ名
+ * @returns ローマ字に変換されたタグ名
+ */
+export const romanizeTagName = (tagName: string): string => {
+  let result = '';
+  let i = 0;
+  
+  while (i < tagName.length) {
+    let found = false;
+    
+    // 2文字の拗音をチェック
+    if (i < tagName.length - 1) {
+      const twoChar = tagName.substring(i, i + 2);
+      if (hiraganaToRomaji[twoChar] || katakanaToRomaji[twoChar]) {
+        result += hiraganaToRomaji[twoChar] || katakanaToRomaji[twoChar];
+        i += 2;
+        found = true;
+      }
+    }
+    
+    // 1文字をチェック
+    if (!found) {
+      const oneChar = tagName.charAt(i);
+      if (hiraganaToRomaji[oneChar] || katakanaToRomaji[oneChar]) {
+        result += hiraganaToRomaji[oneChar] || katakanaToRomaji[oneChar];
+      } else if (/[a-zA-Z0-9]/.test(oneChar)) {
+        // 英数字はそのまま
+        result += oneChar.toLowerCase();
+      } else if (oneChar === ' ' || oneChar === '　') {
+        // スペースはハイフンに変換
+        result += '-';
+      } else {
+        // その他の文字は無視するか、必要に応じて処理
+        result += oneChar;
+      }
+      i++;
+    }
+  }
+  
+  // 連続するハイフンを1つにまとめ、前後のハイフンを削除
+  return result.replace(/-+/g, '-').replace(/^-|-$/g, '');
+};
+
+/**
+ * ローマ字のタグ名から元のタグ名を逆引きする（完全一致）
+ * @param romanizedTag ローマ字のタグ名
+ * @param allTags 全てのタグのリスト
+ * @returns 元のタグ名（見つからない場合はnull）
+ */
+export const findOriginalTagName = (romanizedTag: string, allTags: Array<{ name: string }>): string | null => {
+  for (const tag of allTags) {
+    if (romanizeTagName(tag.name) === romanizedTag) {
+      return tag.name;
+    }
+  }
+  return null;
+};


### PR DESCRIPTION
Implements a tag page (`/[tag]`) to list books by tag, using romanized Japanese tag names for routing.

---
<a href="https://cursor.com/background-agent?bcId=bc-952ab253-4eeb-4c62-8a4f-84d98bf27702">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-952ab253-4eeb-4c62-8a4f-84d98bf27702">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

