### PR TITLE
Fix tag navigation to tag page

### DIFF
--- a/frontend/src/components/TagPage.tsx
+++ b/frontend/src/components/TagPage.tsx
@@ -93,6 +93,11 @@ const TagPage: React.FC = () => {
     window.open(amazonLink, '_blank', 'noopener,noreferrer');
   };
 
+  const handleTagClick = (tagName: string, event: React.MouseEvent) => {
+    event.stopPropagation(); // イベントの伝播を停止してbook clickを防ぐ
+    navigate(`/${encodeURIComponent(tagName)}`);
+  };
+
   if (isLoading) {
     return (
       <div className="min-h-screen bg-gradient-to-br from-amber-50 via-orange-50 to-yellow-50 flex items-center justify-center">
@@ -183,10 +188,11 @@ const TagPage: React.FC = () => {
                         return (
                           <span
                             key={bookTag.id}
-                            className={`px-3 py-1 rounded-full text-sm font-medium border transition-colors ${
+                            onClick={(e) => handleTagClick(bookTag.name, e)}
+                            className={`px-3 py-1 rounded-full text-sm font-medium border transition-colors cursor-pointer ${
                               isCurrentTag
-                                ? 'bg-orange-200 text-orange-800 border-orange-300 ring-2 ring-orange-300'
-                                : `${colors.bg} ${colors.text} ${colors.border} hover:scale-105`
+                                ? 'bg-orange-200 text-orange-800 border-orange-300 ring-2 ring-orange-300 hover:bg-orange-300'
+                                : `${colors.bg} ${colors.text} ${colors.border} hover:scale-105 hover:shadow-sm`
                             }`}
                           >
                             <span className="mr-1">🏷️</span>


### PR DESCRIPTION
Enable tag components on `/[tag]` pages to navigate to their respective tag pages, preventing unintended Amazon redirection.

Previously, clicking a tag on the `/[tag]` page would incorrectly navigate to Amazon due to event bubbling to the parent book container's click handler. This change adds a dedicated tag click handler that navigates to the tag's page and stops event propagation, preserving the book title's Amazon link functionality.

---
<a href="https://cursor.com/background-agent?bcId=bc-93ffb7c9-e57d-47cc-93ac-b78121613534">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-93ffb7c9-e57d-47cc-93ac-b78121613534">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

