### PR TITLE
Update tags page mobile title and alignment

### DIFF
--- a/frontend/src/components/TagsListPage.tsx
+++ b/frontend/src/components/TagsListPage.tsx
@@ -109,10 +109,10 @@ const TagsListPage: React.FC = () => {
       {/* ヘッダー - 固定位置 */}
       <div className="sticky top-0 z-10 bg-white/90 backdrop-blur-sm border-b border-orange-100 shadow-sm">
         <div className="container mx-auto px-4 py-4">
-          <div className="flex items-center justify-between">
+          <div className="relative flex items-center">
             <button
               onClick={() => navigate(-1)}
-              className="flex items-center text-orange-600 hover:text-orange-700 transition-colors"
+              className="absolute left-0 flex items-center text-orange-600 hover:text-orange-700 transition-colors"
             >
               <svg className="w-5 h-5 mr-2" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                 <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M15 19l-7-7 7-7" />
@@ -120,10 +120,10 @@ const TagsListPage: React.FC = () => {
               戻る
             </button>
             
-            <div className="flex items-center">
+            <div className="flex items-center mx-auto">
               <span className="text-2xl mr-3">🏷️</span>
               <div>
-                <h1 className="text-xl font-bold text-gray-800">タグ一覧</h1>
+                <h1 className="text-xl font-bold text-gray-800">🔍探す</h1>
                 <p className="text-sm text-gray-600">{tags.length}個のタグ</p>
               </div>
             </div>


### PR DESCRIPTION
Adjust TagsListPage mobile UI by centering the title and updating its text to avoid overlap with the hamburger menu.

---
<a href="https://cursor.com/background-agent?bcId=bc-6146b581-bb3d-44ac-b66e-096315d1322e">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-6146b581-bb3d-44ac-b66e-096315d1322e">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

