### PR TITLE
Change hamburger menu tag list to search

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -135,7 +135,7 @@ function AppContent() {
                 onClick={() => setIsMenuOpen(false)}
                 className="block px-4 py-3 text-gray-700 hover:bg-orange-50 hover:text-orange-700 transition-colors"
               >
-                🏷️ タグ一覧
+                🔍 探す
               </Link>
               
               <div className="border-t border-orange-100 mt-2 pt-2">


### PR DESCRIPTION
Change '🏷️ タグ一覧' to '🔍 探す' in the hamburger menu.

---
<a href="https://cursor.com/background-agent?bcId=bc-1ed781aa-4c4b-4ca1-ba69-15f3259df303">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-1ed781aa-4c4b-4ca1-ba69-15f3259df303">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

