### PR TITLE
Analyze and fix issue 219

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -45,7 +45,7 @@ function PageTracker() {
 
 function AppContent() {
   const [isMenuOpen, setIsMenuOpen] = useState(false);
-  const { isAuthenticated, logout } = useAuth();
+  const { isAuthenticated, isLoading, logout } = useAuth();
   const navigate = useNavigate();
 
   const toggleMenu = () => {
@@ -58,6 +58,20 @@ function AppContent() {
     // ログアウト後はホームページ（SelectionScreen）にリダイレクト
     navigate('/');
   };
+
+  // 認証状態の初期化中はローディング表示
+  if (isLoading) {
+    return (
+      <div className="min-h-screen bg-gradient-to-br from-amber-50 via-orange-50 to-yellow-50 flex items-center justify-center">
+        <div className="bg-white/80 backdrop-blur-sm rounded-2xl shadow-xl p-8 border border-orange-100">
+          <div className="flex flex-col items-center">
+            <div className="animate-spin rounded-full h-8 w-8 border-b-2 border-orange-500 mb-4"></div>
+            <p className="text-gray-600 text-sm">初期化中...</p>
+          </div>
+        </div>
+      </div>
+    );
+  }
 
   return (
     <>

--- a/frontend/src/contexts/AuthContext.tsx
+++ b/frontend/src/contexts/AuthContext.tsx
@@ -14,6 +14,7 @@ interface AuthContextType {
   login: (token: string, user: User) => void;
   logout: () => void;
   isAuthenticated: boolean;
+  isLoading: boolean;
 }
 
 const AuthContext = createContext<AuthContextType | undefined>(undefined);
@@ -33,6 +34,7 @@ interface AuthProviderProps {
 export const AuthProvider: React.FC<AuthProviderProps> = ({ children }) => {
   const [user, setUser] = useState<User | null>(null);
   const [token, setToken] = useState<string | null>(null);
+  const [isLoading, setIsLoading] = useState(true);
 
   useEffect(() => {
     // ローカルストレージから認証情報を復元
@@ -49,6 +51,9 @@ export const AuthProvider: React.FC<AuthProviderProps> = ({ children }) => {
         localStorage.removeItem('authUser');
       }
     }
+    
+    // 初期化完了
+    setIsLoading(false);
   }, []);
 
   const login = (newToken: string, newUser: User) => {
@@ -71,6 +76,7 @@ export const AuthProvider: React.FC<AuthProviderProps> = ({ children }) => {
     login,
     logout,
     isAuthenticated: !!token,
+    isLoading,
   };
 
   return (


### PR DESCRIPTION
Add loading state to AuthContext and handle it in App.tsx to resolve persistent loading spinner for unauthenticated users (Issue #219).

Previously, the application lacked proper loading state management during the initial authentication check from local storage. This caused the loading spinner to display indefinitely on the homepage for unauthenticated users until the `isAuthenticated` state was resolved. The changes introduce an `isLoading` state in `AuthContext` and ensure `App.tsx` displays a temporary loading screen until authentication initialization is complete, then renders the appropriate content.

---
<a href="https://cursor.com/background-agent?bcId=bc-d724fc2f-18b1-45a9-86b0-f4a06c0f8e63">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-d724fc2f-18b1-45a9-86b0-f4a06c0f8e63">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

