### PR TITLE
Add and display book summary links

### DIFF
--- a/backend/src/database.ts
+++ b/backend/src/database.ts
@@ -915,6 +915,9 @@ export interface Book {
   id?: number;
   title: string;
   amazon_link: string;
+  summary_link1?: string | null;
+  summary_link2?: string | null;
+  summary_link3?: string | null;
   created_at?: string;
   updated_at?: string;
 }

--- a/frontend/src/components/TagPage.tsx
+++ b/frontend/src/components/TagPage.tsx
@@ -13,6 +13,9 @@ interface Book {
   id: number;
   title: string;
   amazon_link: string;
+  summary_link1?: string | null;
+  summary_link2?: string | null;
+  summary_link3?: string | null;
   created_at: string;
   updated_at: string;
   tags: Tag[];
@@ -357,6 +360,50 @@ const TagPage: React.FC = () => {
                     </div>
                   )}
                 </div>
+
+                {/* 新規追加: 要約リンクセクション */}
+                {(book.summary_link1 || book.summary_link2 || book.summary_link3) && (
+                  <div className="mb-4">
+                    <div className="flex flex-wrap gap-2">
+                      {book.summary_link1 && (
+                        <button
+                          onClick={(e) => {
+                            e.stopPropagation();
+                            window.open(book.summary_link1!, '_blank', 'noopener,noreferrer');
+                          }}
+                          className="inline-flex items-center px-3 py-1.5 text-sm font-medium bg-purple-100 hover:bg-purple-200 text-purple-800 border border-purple-200 rounded-lg transition-colors"
+                        >
+                          <span className="mr-1">📝</span>
+                          要約1
+                        </button>
+                      )}
+                      {book.summary_link2 && (
+                        <button
+                          onClick={(e) => {
+                            e.stopPropagation();
+                            window.open(book.summary_link2!, '_blank', 'noopener,noreferrer');
+                          }}
+                          className="inline-flex items-center px-3 py-1.5 text-sm font-medium bg-purple-100 hover:bg-purple-200 text-purple-800 border border-purple-200 rounded-lg transition-colors"
+                        >
+                          <span className="mr-1">📝</span>
+                          要約2
+                        </button>
+                      )}
+                      {book.summary_link3 && (
+                        <button
+                          onClick={(e) => {
+                            e.stopPropagation();
+                            window.open(book.summary_link3!, '_blank', 'noopener,noreferrer');
+                          }}
+                          className="inline-flex items-center px-3 py-1.5 text-sm font-medium bg-purple-100 hover:bg-purple-200 text-purple-800 border border-purple-200 rounded-lg transition-colors"
+                        >
+                          <span className="mr-1">📝</span>
+                          要約3
+                        </button>
+                      )}
+                    </div>
+                  </div>
+                )}
 
                 {/* 第3セクション: 編集・削除ボタン */}
                 {isAuthenticated && user?.userId === '115610079057789909588' && (


### PR DESCRIPTION
Add summary links to book cards on tag pages to display external summary information registered via `/admin/register`.

---
<a href="https://cursor.com/background-agent?bcId=bc-46b815c7-5b11-4ed6-b068-79eb5d52615f">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-46b815c7-5b11-4ed6-b068-79eb5d52615f">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

