### PR TITLE
Fix book registration unauthorized error

### DIFF
--- a/frontend/src/components/BookRegisterPage.tsx
+++ b/frontend/src/components/BookRegisterPage.tsx
@@ -59,8 +59,15 @@ const BookRegisterPage: React.FC = () => {
   // コンポーネントマウント時に認証状態をチェック
   useEffect(() => {
     const authStatus = localStorage.getItem('adminAuthenticated');
-    if (authStatus === 'true') {
+    const savedUsername = localStorage.getItem('adminUsername');
+    const savedPassword = localStorage.getItem('adminPassword');
+    
+    if (authStatus === 'true' && savedUsername && savedPassword) {
       setIsAuthenticated(true);
+      setLoginForm({
+        username: savedUsername,
+        password: savedPassword
+      });
     }
   }, []);
 
@@ -74,6 +81,8 @@ const BookRegisterPage: React.FC = () => {
       if (loginForm.username === 'noap3b69n' && loginForm.password === '19930322') {
         setIsAuthenticated(true);
         localStorage.setItem('adminAuthenticated', 'true');
+        localStorage.setItem('adminUsername', loginForm.username);
+        localStorage.setItem('adminPassword', loginForm.password);
         setSuccess('認証に成功しました');
       } else {
         setError('ユーザー名またはパスワードが間違っています');
@@ -278,6 +287,20 @@ const BookRegisterPage: React.FC = () => {
                 aria-label="書籍一覧"
               >
                 📚
+              </button>
+              <button
+                onClick={() => {
+                  localStorage.removeItem('adminAuthenticated');
+                  localStorage.removeItem('adminUsername');
+                  localStorage.removeItem('adminPassword');
+                  setIsAuthenticated(false);
+                  setLoginForm({ username: '', password: '' });
+                }}
+                className="bg-red-600 text-white w-10 h-10 rounded-lg hover:bg-red-700 transition-colors flex items-center justify-center"
+                title="ログアウト"
+                aria-label="ログアウト"
+              >
+                🚪
               </button>
             </div>
           </div>


### PR DESCRIPTION
Persist admin login credentials and add a logout feature to resolve 401 Unauthorized errors during book registration.

The 401 Unauthorized error occurred because the frontend was not correctly persisting the username and password used for admin login. This meant subsequent API calls for book registration lacked the necessary authentication, as the backend's `authenticateAdmin` middleware expected these credentials.

---
<a href="https://cursor.com/background-agent?bcId=bc-7a51b6b7-3ccc-4ad7-bd93-784ef122a674">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-7a51b6b7-3ccc-4ad7-bd93-784ef122a674">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

